### PR TITLE
Add rapid scraping

### DIFF
--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,4 +18,22 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Web scraper to scrape the CAZy website."""

--- a/scraper/cazy_webscraper.py
+++ b/scraper/cazy_webscraper.py
@@ -40,21 +40,21 @@
 Web scraper to scrape CAZy website and retrieve all protein data.
 
 :cmd_args --config: path to configruration file
-:cmd args --data_split: [None, class, family] how data is to be split/separated into dataframes
+:cmd_args --classes: specify CAZy classes to scrape
+:cmd_args --database: provide path to a local SQL database to add additional data to
+:cmd_args --families: specify CAZy families to retrieve CAZymes from
 :cmd_args --force: force overwriting content in exisiting output directory
+:cmd_args --genera: specify Genera to retrieve CAZymes from
+:cmd_args --kingdoms: specify taxonomy Kingdoms to scrape proteins from
 :cmd_args --log: path to log file, enables writing out log messages to a log file
 :cmd_args --nodelete: if true does not delete content in pre-existing output directory
 :cmd_args --output: path to output directory
-:cmd_args --subfamily: enable retrieval of subfamilies from CAZy
+:cmd_args --retries: specify the number of times to try scraping a page if connection fails
+:cmd_args --subfamilies: enable retrieval of subfamilies from CAZy
+:cmd_args --species: specify species to retrieve CAZymes from
+:cmd_args --strains: specify specific strains of species to retrieve CAZymes from
+:cmd_args --timeout: specify the maximum time (in seconds) before determining connection timed out
 :cmd_args --verbose: change logger level from warning to info, verbose logging
-
-:func main: coordinate scraping of CAZy database
-:func get_class_urls: retrieve URLs to CAZy class summary pages from CAZy homepage
-:func browser_decorator: decorator for get_page() to coordinate retrying failed connections
-:func get_page: connect to webpage and retrieval page as BeautifulSoup4 object
-
-:class Protein: A single protein from CAZy database
-:class Family: A single family from CAZy containing proteins
 """
 
 

--- a/scraper/cazy_webscraper.py
+++ b/scraper/cazy_webscraper.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """
 Web scraper to scrape CAZy website and retrieve all protein data.
 

--- a/scraper/crawler/__init__.py
+++ b/scraper/crawler/__init__.py
@@ -627,6 +627,13 @@ def row_to_protein(row, family_name, taxonomy_filters, kingdom, session):
     # create dict for storing error messages for writing to the failed_to_scrape output file
     report_dict = {"url": None, "error": None, "sql": None}
 
+    # if a single UniProt accession is listed, and not in bold, write as primary accession
+    # if multiple UniProt accessions are listed and none are in bold, the first is the priarmy
+    if len(uni_primary) == 0:
+        if len(uni_nonprimary) != 0:
+            uni_primary.append(uni_nonprimary[0])
+            uni_nonprimary.remove(uni_nonprimary[0])
+
     # Remove primary GenBank accessions from the non-primary accessions list
     if len(gbk_primary) == 0:
         if len(gbk_nonprimary) == 0:

--- a/scraper/crawler/__init__.py
+++ b/scraper/crawler/__init__.py
@@ -329,6 +329,8 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
     :param cazy_home: str, URL to CAZy home page
     :param taxonomy_filters: set of genera, species and strains to restrict the scrape to
     :param kingdoms: list of taxonomy Kingdoms to restrict the scrape to
+        OR a str if the user did not define any Kingdoms to scrape  (enables faster
+        scraping via the 'all' pages)
     :param args: cmd-line args parser
     :param session: open SQL database session
 
@@ -338,6 +340,16 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
     """
     logger = logging.getLogger(__name__)
     logger.info(f"Starting retrieval of proteins for {family.name} from {family.url}")
+
+    if kingdoms == 'all':  # retrieve proteins from the proteins listed in 'all' pages
+        family, retry_scrape, failed_scrapes, sql_failures = parse_family_via_all_pages(
+            family,
+            cazy_home,
+            taxonomy_filters,
+            args,
+            session,
+        )
+        return family, retry_scrape, failed_scrapes, sql_failures
 
     if len(list(family.failed_pages.keys())) != 0:  # retrying scrape
         kingdoms = list(family.failed_pages.keys())
@@ -363,8 +375,8 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
                 "Will not try and connect to this URL."
             )
             failed_scrapes.append(
-                f"Incorrect URL format for the first protein table page for {family.name} "
-                f"in kingdom {kingdom}"
+                f"{first_pagination_url}\tIncorrect URL format for the first protein table page "
+                f"for {family.name} in kingdom {kingdom}"
             )
             continue  # could not scrape any CAZymes for the Kingdom
 
@@ -380,17 +392,14 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
                 f"Could not connect to {first_pagination_url} after 10 attempts\n"
                 f"The following error was raised:\n{error_message}"
             )
-            if 1 >= args.retries:
-                failed_scrapes.append(
-                    "Could not conenct to first paginiation page to get all paginiation page URLs "
-                    f"for {family.name}, kingdom: {kingdom}.\n"
-                    f"Scraped no CAZymes from {family.name}, kingdom: {kingdom}"
-                )
-            else:
-                family.failed_pages[kingdom] = {(first_pagination_url): 1}
+            failed_scrapes.append(
+                f"{first_paginiation_url}\tCould not conenct to first paginiation page to get "
+                f"all paginiation page URLs for {family.name}, kingdom: {kingdom}.\n"
+                f"Therefore, did not scrape any CAZymes from {family.name}, kingdom: {kingdom}"
+            )
             continue
 
-        protein_page_urls, total_proteins = get_protein_page_urls(
+        protein_page_urls, total_proteins = get_tax_page_urls(
             first_pagination_url,
             first_pagination_page,
             kingdom,
@@ -398,6 +407,7 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
             family.name,
         )
         if total_proteins == 0:
+            logger.warning(f"Protein count for {family.name} retrieved == 0")
             continue
 
         # Retrieve the CAZymes (proteins) and write to the local database
@@ -428,7 +438,7 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
                 except KeyError:  # first failed attempt for the family:kingdom
                     family.failed_pages[kingdom] = {protein["url"]: 1}
 
-                if family.failed_pages[kingdom][protein["url"]] == args.retries:
+                if family.failed_pages[kingdom][protein["url"]] >= (args.retries + 1):
                     # Reached maximum attempts number of attempted connections ...
                     failed_scrapes.append(
                         f"{protein['url']}\t{family.cazy_class}\t"
@@ -453,7 +463,7 @@ def parse_family(family, cazy_home, taxonomy_filters, kingdoms, args, session):
     return family, retry_scrape, failed_scrapes, sql_failures
 
 
-def get_protein_page_urls(
+def get_tax_page_urls(
     first_pagination_url,
     first_pagination_page,
     kingdom,
@@ -531,7 +541,7 @@ def parse_proteins(protein_page_url, family_name, taxonomy_filters, kingdom, arg
     logger = logging.getLogger(__name__)
     logger.info(f"Retrieving proteins from {protein_page_url}")
 
-    protein_page, error = get_page(protein_page_url, args, max_tries=(args.retries + 1))
+    protein_page, error = get_page(protein_page_url, args, max_tries=args.retries)
 
     if protein_page is None:
         logger.warning(
@@ -564,6 +574,241 @@ def parse_proteins(protein_page_url, family_name, taxonomy_filters, kingdom, arg
     for row in cazyme_rows:
         yield row_to_protein(row, family_name, taxonomy_filters, kingdom, session)
 
+
+def parse_family_via_all_pages(family, cazy_home, taxonomy_filters, args, session):
+    """Parse the protein tables from the 'all' pages of CAZy family.
+
+    CAZy families have separate series of HTML tables for each taxonomy Kingdom, and a single series
+    of HTML tables containing all proteins from all Kingdoms, called 'all'. These 'all' pages
+    containing 1000 proteins per page and thus scraping these pages is significantly faster than
+    scraping all the specific Kingdom HTML tables (which hold only 100 proteins each, and thus
+    require more calls to CAZy).
+
+    :param family: Family class object, representation of CAZy family
+    :param cazy_home: str, URL to CAZy home page
+    :param taxonomy_filters: set of genera, species and strains to restrict the scrape to
+    :param args: cmd-line args parser
+    :param session: open SQL database session
+
+    Return Family object, Boolean whether to scrape the family again, a list of URLs which couldn't
+    connect to CAZy (and no have re-try attempts left) and list of proteins that could not be added
+    to the SQL database.
+    """
+    # check if there were pagination pages to which a connection could not be made previously
+    if len(list(family.failed_pages.keys())) != 0:
+        protein_page_urls = list(family.failed_pages.keys())
+        total_proteins = len(protein_page_urls * 1000)
+
+    else:  # scraping family for the first time so retrieve the URLs to the pagination pages
+        # compile URL to first family page of protein records
+        first_pagination_url = family.url.replace(".html", "_all.html")
+        # check url formating of first paginiation url
+        try:
+            re.match(
+                r"http://www.cazy.org/\D{2,3}(\d+|\d+_\d+)_all.html", first_pagination_url
+            ).group()
+        except AttributeError:
+            logger.warning(
+                f"Incorrect formatting of first protein table page URL: {first_pagination_url}\n"
+                "Will not try and connect to this URL."
+            )
+            return(
+                family,
+                False,
+                [
+                    f"{first_pagination_url}\t{family.cazy_class}\t"
+                    f"Incorrect URL format, could not connect to CAZy for {family.name}"
+                ],
+                [],
+            )
+
+        # retrieve a list of all page urls of protein tables for the CAZy family
+        first_pagination_page, error_message = get_page(first_pagination_url, args.retries)
+
+        if first_pagination_page is None:
+            logger.warning(
+                    f"Could not connect to {first_pagination_url} after 10 attempts\n"
+                    f"The following error was raised:\n{error_message}\nTherefore, could not "
+                    "retrieve all pagination pages URLs, therefore, cannot scrape proteins from "
+                    f"{family.name}"
+            )
+            return(
+                family,
+                False,
+                [
+                    f"{first_pagination_url}\t{family.cazy_class}\t"
+                    f"Failed to connect to first pagination page for {family.name}, therefore "
+                    f"could not retrieve URLs to all paginiation pages\t{error_message}"
+                ],
+                [],
+            )
+
+        # Get the URLS to all pages of proteins and the total number of proteins in the (sub)family
+        protein_page_urls, total_proteins = get_paginiation_page_urls(
+            first_pagination_url,
+            first_pagination_page,
+            cazy_home,
+        )
+
+        if len(protein_page_urls) == 0:
+            return(
+                family,
+                False,
+                [
+                    f"{first_pagination_url}\t{family.cazy_class}\t"
+                    f"Failed to retrieve URLs to protein table pages for {family.name}\t"
+                    f"No specific error message availble."
+                ],
+                [],
+            )
+
+    # Scrape proteins from CAZy
+    # define lists for storing error messages during scraping and parsing proteins
+    failed_scrapes = []  # URLs of pages for which maximum number of scrape attempts is MET
+    sql_failures = []
+
+    for protein in tqdm(
+        (y for x in (
+            parse_proteins_from_all(
+                url,
+                family.name,
+                taxonomy_filters,
+                session,
+                args,
+            ) for url in protein_page_urls
+        ) for y in x),
+        total=total_proteins,
+        desc=f"Parsing protein pages for {family.name}",
+    ):
+        if protein["url"] is not None:  # Protein was not retrieved because couldn't connect to CAZy
+            try:
+                family.failed_pages[protein["url"]] += 1
+            except KeyError:
+                family.failed_pages[protein["url"]] = 1  # First failed attempt to connect to page
+
+            if family.failed_pages[protein["url"]] == args.retries:
+                # maximum attempts to connect have been reached no more attempts made, write to file
+                failed_scrapes.append(
+                    f"{protein['url']}\t{family.cazy_class}\t"
+                    f"Failed to connect to this page of proteins for {family.name}, "
+                    f"and raised the following error message:\n{protein['error']}"
+                )
+                # ... and do no attempt to scrape again
+                del family.failed_paged[protein["url"]]
+
+        if protein["sql"] is not None:  # Error occured when adding Protein to SQL database
+            sql_failures.append(
+                f"{protein['sql']} was not added to the database\t"
+                f"and raised the following error when atempting to do so:\n{protein['error']}"
+            )
+
+    # check if any pages for the family still have attempts left for trying for a successful scrape
+    if len(list(family.failed_pages.keys())) == 0:
+        retry_scrape = False
+    else:
+        retry_scrape = True
+
+    return family, retry_scrape, failed_scrapes, sql_failures
+
+
+def get_paginiation_page_urls(first_pagination_url, first_pagination_page, cazy_home):
+    """Retrieve the URLs to all pages containing proteins for the current working family.
+
+    Also retrieve the total number of proteins catagloued under the family.
+
+    :param first_pagination_url: str, URL to first page contaiing proteins
+    :param first_pagination_page: BS4 object, first page containing proteins
+    :param cazy_home: str, URL of CAZy homepage
+
+    Return list of URLs, and number of proteins in the family.
+    """
+    protein_page_urls = [first_pagination_url]
+
+    # retrieve the URL to the final page of protein records in the pagination listing
+    try:
+        last_pagination_url = first_pagination_page.find_all(
+            "a", {"class": "lien_pagination", "rel": "nofollow"}
+        )[-1]
+    except IndexError:  # there is no pagination; a single-query entry
+        last_pagination_url = None
+
+    if last_pagination_url is not None:
+        url_prefix = last_pagination_url["href"].split("PRINC=")[0] + "PRINC="
+        last_princ_no = int(last_pagination_url["href"].split("PRINC=")[-1].split("#pagination")[0])
+        url_suffix = "#pagination" + last_pagination_url["href"].split("#pagination")[-1]
+        # Build list of urls to all pages in the pagination listing, increasing the PRINC increment
+        protein_page_urls.extend(
+            [f"{cazy_home}/{url_prefix}{_}{url_suffix}" for _ in range(
+                1000, last_princ_no + 1000, 1000
+            )]
+        )
+
+    # retrieve the data element that contains the links the sets of HTML tables
+    data = first_page.find_all("div", {"class": "pos_choix"})
+    
+    # retrieve the number of proteins listed after 'all' in the data
+    try:
+        protein_total = int(re.findall(
+            r"all \(\d+\)", data[0].text, flags=re.IGNORECASE,
+        )[0].split("(")[1][:-1])
+    except IndexError:
+        logger.warning(f"No proteins found for 'all' in {family_name}")
+        protein_total = 0
+
+    return protein_page_urls, protein_total
+
+
+def parse_proteins_from_all(url, family_name, taxonomy_filters, session, args):
+    """Parse proteins from the paginiation page.
+
+    Returns generator of Protein objects for all protein rows on a single CAZy family page. Returns
+    a dictionary containing any errors that arose. If it an attempt to connect to CAZy
+    failed the URL is stored under "url". The "sql" key is used to store the name of the protein
+    which raised an SQL error further down the pipeline.
+
+    :param protein_page_url, str, URL to the CAZy family page containing protein records
+    :param family_name: str, name of CAZy family
+    :param taxonomy_filters: set of genera, species and strains to restrict the scrape to
+    :param kingdom: str, Taxonomy Kingdom of CAZymes currently being scraped
+    :param args: cmd-line args parser
+    :param session: open SQL database session
+
+    Return generator object.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info(f"Retrieving proteins from {protein_page_url}")
+
+    # connect to page
+    protein_page, error = get_page(protein_page_url, args.retries)
+    if protein_page is None:
+        logger.warning(
+            (
+                f"Could not connect to {protein_page_url} after 10 attempts\n"
+                "The following error was raised:\n"
+                f"{error}\n"
+                f"No protein records from this page will be retried."
+            )
+        )
+        return {"url": protein_page_url, "error": error, "sql": None}
+    
+    # retrive the table of proteins
+    cazyme_table = protein_page.select("table")[1]
+
+    tax_kingdom = ''  # Archaea, Bacteria, Eukaryota, Viruses, unclassified
+    for row in cazyme_table.select("tr"):
+        try:
+            if (row.attrs["class"] == ['royaume']) and (if row.text.strip() != 'Top'):
+                # Row defines the Kingdom
+                tax_kingdom = row.text.strip()
+                continue  # row does not contain protein
+            else:  # result when row containing 'Top', becuase reached end of the page
+                continue  # row does not contain protein
+        except KeyError:
+            pass
+        
+        if ('class' not in row.attrs) and ('id' not in row.attrs):  # row contains protein data
+            yield row_to_protein(row, family_name, taxonomy_filters, kingdom, session)
+            
 
 def row_to_protein(row, family_name, taxonomy_filters, kingdom, session):
     """Returns a Protein object representing a single protein row from a CAZy family protein page.
@@ -627,13 +872,6 @@ def row_to_protein(row, family_name, taxonomy_filters, kingdom, session):
     # create dict for storing error messages for writing to the failed_to_scrape output file
     report_dict = {"url": None, "error": None, "sql": None}
 
-    # if a single UniProt accession is listed, and not in bold, write as primary accession
-    # if multiple UniProt accessions are listed and none are in bold, the first is the priarmy
-    if len(uni_primary) == 0:
-        if len(uni_nonprimary) != 0:
-            uni_primary.append(uni_nonprimary[0])
-            uni_nonprimary.remove(uni_nonprimary[0])
-
     # Remove primary GenBank accessions from the non-primary accessions list
     if len(gbk_primary) == 0:
         if len(gbk_nonprimary) == 0:
@@ -652,45 +890,63 @@ def row_to_protein(row, family_name, taxonomy_filters, kingdom, session):
 
         else:
             warning = (
-                f"Multiple primary GenBank accessions retrieved for {protein_name} in "
-                f"{family_name}.\n"
-                f"The first listed primary accession {gbk_primary[0]} listed as the primary.\n"
+                f"Multiple GenBank accessions retrieved for {protein_name} in "
+                f"{family_name}.\nBut none were defined as primary.\n"
+                f"The first non-primary accession {gbk_nonprimary[0]} is listed as the primary.\n"
                 f"Remaining primary accessions listed as non-primary accessions for {protein_name}"
             )
             logger.warning(warning)
             report_dict["error"] = warning
             report_dict["sql"] = protein_name
+            gbk_primary.append(gbk_nonprimary[0])
+            gbk_nonprimary.remove(gbk_nonprimary[0])
+    
+    elif len(gbk_primary) > 1:
+        warning = (
+            f"Multiple primary GenBank acccessions retrieved for {protein_name} in "
+            f"{family_name}.\nOnly the first listed accession will be written as primary."
+        )
+        logger.warning(warning)
+        report_dict["error"] = warning
+        report_dict["sql"] = protein_name
+        for gbk_acc in gbk_primary[1:]:
+            warning = (
+                f"GenBank accession {gbk_acc} written as primary in CAZy,\n"
+                "but listed as non-primary in the local database."
+            )
+            logger.warning(warning)
+            gbk_nonprimary.append(gbk_acc)
+            gbk_primary.remove(gbk_acc)
+            logger.warning(warning)
 
-    else:
-        for acc in gbk_primary:
-            try:
-                gbk_nonprimary.remove(acc)
-            except ValueError:
-                pass
+
+    for acc in gbk_primary:
+        try:
+            gbk_nonprimary.remove(acc)
+        except ValueError:
+            pass
 
     # Remove primary UniProt accessions from the non-primary accessions list
     if len(uni_primary) == 0:
-        if len(uni_nonprimary) == 1:
+        if len(uni_nonprimary) >= 1:
             uni_primary = uni_nonprimary
             uni_nonprimary.remove(uni_nonprimary[0])
 
-        elif len(uni_primary) > 1:
-            warning = (
-                f"Multiple primary UniProt accessions retrieved for {protein_name} in "
-                f"{family_name}.\n"
-                f"The first listed primary accession {gbk_primary[0]} listed as the primary.\n"
-                f"Remaining primary accessions listed as non-primary accessions for {protein_name}"
-            )
-            logger.warning(warning)
-            report_dict["error"] = warning
-            report_dict["sql"] = protein_name
+    elif len(uni_primary) > 1:
+        warning = (
+            f"Multiple UniProt primary accessions retrieved for {protein_name} in "
+            f"{family_name}.\n"
+            f"All will be listed as primary UniProt accessions."
+        )
+        logger.warning(warning)
+        report_dict["error"] = warning
+        report_dict["sql"] = protein_name
 
-    else:
-        for acc in uni_primary:
-            try:
-                uni_nonprimary.remove(acc)
-            except ValueError:
-                pass
+    for acc in uni_primary:
+        try:
+            uni_nonprimary.remove(acc)
+        except ValueError:
+            pass
 
     # add protein to database
     try:
@@ -713,7 +969,7 @@ def row_to_protein(row, family_name, taxonomy_filters, kingdom, session):
             f"Failed to add {protein_name} to SQL database, "
             f"the following error was raised:\n{error_message}"
         )
-        logger.warning(warning)
+        logger.warning(warning, exc_info=1)
         report_dict["error"] = warning
         report_dict["sql"] = protein_name
 

--- a/scraper/crawler/__init__.py
+++ b/scraper/crawler/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,15 +18,25 @@
 # UK
 
 # The MIT License
-"""Module for crawling through the CAZy website and parsing HTML from the CAZy website.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
-:func get_cazy_family_urls: retrieve URLs to families on CAZy class summary page
-:func get_subfamily_links: retrieve URLs to subfamilies on CAZy class summary page
-:func parse_family: build Family class object to represent CAZy family
-:func parse_family_pages: retrieve all URLs to pages containing protein records for CAZy family
-:func parse_proteins: retrieve protein records from protein table page
-:func row_to_protein: parse the protein record to build a Protein class object
-"""
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Module for crawling through the CAZy website and parsing HTML from the CAZy website."""
 
 
 import logging

--- a/scraper/expand/__init__.py
+++ b/scraper/expand/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,4 +18,22 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """A module for expanding the the local CAZY database beyond what is provided within CAZy."""

--- a/scraper/expand/get_genbank_sequences.py
+++ b/scraper/expand/get_genbank_sequences.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Retrieve proteins sequences from GenBank and populate the local database and write to FASTA"""
 
 

--- a/scraper/expand/get_pdb_structures.py
+++ b/scraper/expand/get_pdb_structures.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,7 +18,25 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 # Bio.PDB reference:
 # Hamelryck, T., Manderick, B. (2003) PDB parser and structure class 
 # implemented in Python. Bioinformatics 19: 2308–2310

--- a/scraper/sql/__init__.py
+++ b/scraper/sql/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,4 +18,22 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Module for building and querying an SQL database."""

--- a/scraper/sql/sql_interface.py
+++ b/scraper/sql/sql_interface.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Submodule for interacting with a local SQL database"""
 
 

--- a/scraper/sql/sql_interface.py
+++ b/scraper/sql/sql_interface.py
@@ -301,6 +301,7 @@ def add_new_protein_to_db(
     except IntegrityError:  # raised when Kingdom is already in the Kingdom table
         session.rollback()
         # retrieve the existing Kingdom instance
+        tax_kingdom = f'{tax_kingdom[0].upper()}{tax_kingdom[1:]}'
         new_kingdom = session.query(Kingdom).filter(Kingdom.kingdom == tax_kingdom).all()[0]
 
     # define source organism

--- a/scraper/sql/sql_interface.py
+++ b/scraper/sql/sql_interface.py
@@ -305,9 +305,14 @@ def add_new_protein_to_db(
         new_kingdom = session.query(Kingdom).filter(Kingdom.kingdom == tax_kingdom).all()[0]
 
     # define source organism
-    genus_sp_separator = source_organism.find(" ")
-    genus = source_organism[:genus_sp_separator]
-    species = source_organism[genus_sp_separator:]
+    if source_organism == 'unidentified':
+        genus = source_organism
+        species = source_organism
+
+    else:
+        genus_sp_separator = source_organism.find(" ")
+        genus = source_organism[:genus_sp_separator]
+        species = source_organism[genus_sp_separator:]
 
     # Add the CAZyme and its taxonomy data
     try:

--- a/scraper/sql/sql_orm.py
+++ b/scraper/sql/sql_orm.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Submodule to build a local SQL database"""
 
 import logging

--- a/scraper/utilities/__init__.py
+++ b/scraper/utilities/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Module containing functions for building parsers, loggers and parsing configuration."""
 
 

--- a/scraper/utilities/file_io/__init__.py
+++ b/scraper/utilities/file_io/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Submodule for handling inputs and outputs"""
 
 

--- a/scraper/utilities/parse_configuration/__init__.py
+++ b/scraper/utilities/parse_configuration/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Module for handling input and output files and directories."""
 
 

--- a/scraper/utilities/parse_configuration/__init__.py
+++ b/scraper/utilities/parse_configuration/__init__.py
@@ -210,7 +210,7 @@ def get_kingdoms(args, raw_config_dict):
 
         else:
             # user did not specify any Kingdoms
-            kingdoms = cazy_kingdoms  # scrape CAZymes from all Kingdoms
+            kingdoms = 'all'  # scrape CAZymes from all Kingdoms
 
     return kingdoms
 

--- a/scraper/utilities/parsers/__init__.py
+++ b/scraper/utilities/parsers/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# (c) University of St Andrews 2020-2021
+# (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
 
@@ -16,6 +18,24 @@
 # UK
 
 # The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Submodule for building cmd-line parsers"""
 
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -208,6 +208,12 @@ def protein_with_no_uniprot_no_pdb(input_dir):
     return file_path
 
 
+@pytest.fixture
+def test_fam():
+    test_fam = crawler.Family("GH3", "Glycoside Hydrolases (GHs)", "http://www.cazy.org/GH1.html")
+    return test_fam
+
+
 # test classes
 
 
@@ -845,3 +851,186 @@ def test_browser_decorator():
     args = {"args": Namespace(timeout=10)}
     result = crawler.get_page('www.caz!!!!!!!!y.org', args["args"], max_tries=1)
     assert True == (result[0] is None) and (type(result[1]) is MissingSchema)
+
+
+# unit tests for parsing HTML pages labelled under 'all'
+
+
+def test_parse_fam_kingdom_all(monkeypatch, cazy_home_url, args_subfam_false, test_fam):
+    """Test parse_family() when kingdoms = 'all'."""
+
+    def mock_parse_all(*args, **kwargs):
+        return test_fam, False, "failed scrapes", "sql_failures"
+
+    monkeypatch.setattr(crawler, "parse_family_via_all_pages", mock_parse_all)
+
+    crawler.parse_family(
+        test_fam,
+        cazy_home_url,
+        None,
+        'all',
+        args_subfam_false['args'],
+        'session',
+    )
+
+
+def test_parsing_all_incorrect_url(cazy_home_url, args_subfam_false):
+    """Test parse_family_via_all_pages() when the URL format is wrong"""
+
+    test_fam = crawler.Family("GH3", "Glycoside Hydrolases (GHs)", "http://www.cssazy.org/GH1.html")
+
+    crawler.parse_family_via_all_pages(
+        test_fam,
+        cazy_home_url,
+        None,
+        args_subfam_false['args'],
+        'session'
+    )
+
+
+def test_parsing_all_no_first_paginiation(test_fam, cazy_home_url, args_subfam_true, monkeypatch):
+    """Test parse_family_via_all_pages() when no page retured for the first pagination page."""
+
+    def mock_get_page(*args, **kwargs):
+        return None, "error message"
+
+    monkeypatch.setattr(crawler, "get_page", mock_get_page)
+
+    crawler.parse_family_via_all_pages(
+        test_fam,
+        cazy_home_url,
+        None,
+        args_subfam_true['args'],
+        'session'
+    )
+
+
+def test_parsing_all_no_paginiation_urls(
+    test_fam,
+    cazy_home_url,
+    args_subfam_true,
+    monkeypatch,
+    gh1_page,
+):
+    """Test parse_family_via_all_pages() when no paginiation page URLs returned."""
+
+    with open(gh1_page) as fp:
+        soup = BeautifulSoup(fp, features="lxml")
+
+    def mock_get_pages(*args, **kwargs):
+        return soup, None
+
+    def mock_get_urls(*args, **kwargs):
+        return [], 0
+
+    monkeypatch.setattr(crawler, "get_page", mock_get_pages)
+    monkeypatch.setattr(crawler, "get_paginiation_page_urls", mock_get_urls)
+
+    crawler.parse_family_via_all_pages(
+        test_fam,
+        cazy_home_url,
+        None,
+        args_subfam_true['args'],
+        'session'
+    )
+
+
+def test_successful_parse_all(test_fam, gh1_page, monkeypatch, args_subfam_true, cazy_home_url):
+    """Test parse_family_via_all_pages() when parse is successful."""
+
+    with open(gh1_page) as fp:
+        soup = BeautifulSoup(fp, features="lxml")
+
+    def mock_get_page(*args, **kwargs):
+        return soup, None
+
+    def mock_page_urls(*args, **kwargs):
+        return ["url1", "url2"], 0
+
+    def mock_parse_proteins(*args, **kwargs):
+        return [
+            {"url": None, "error": None, "sql": None},
+            {"url": None, "error": None, "sql": None},
+        ]
+
+    monkeypatch.setattr(crawler, "get_page", mock_get_page)
+    monkeypatch.setattr(crawler, "get_paginiation_page_urls", mock_page_urls)
+    monkeypatch.setattr(crawler, "parse_proteins_from_all", mock_parse_proteins)
+
+    crawler.parse_family(
+        test_fam,
+        cazy_home_url,
+        None,
+        'all',
+        args_subfam_true['args'],
+        "session",
+    )
+
+
+def test_get_paginiation_urls(monkeypatch, cazy_home_url, gh1_page):
+    """Test get_paginiation_page_urls() when urls successfully retrieved."""
+
+    with open(gh1_page) as fp:
+        soup = BeautifulSoup(fp, features="lxml")
+
+    crawler.get_paginiation_page_urls(
+        "http://www.cazy.org/GH1_all.html",
+        soup,
+        cazy_home_url,
+        "GH147"
+    )
+
+
+def test_get_paginiation_no_last(monkeypatch, cazy_home_url, gh147_page):
+    """Test get_paginiation_page_urls() when urls successfully retrieved."""
+
+    with open(gh147_page) as fp:
+        soup = BeautifulSoup(fp, features="lxml")
+
+    crawler.get_paginiation_page_urls(
+        "http://www.cazy.org/GH147_all.html",
+        soup,
+        cazy_home_url,
+        "GH147",
+    )
+
+
+def test_parse_proteins_all_no_page(monkeypatch, args_subfam_true):
+    """Test parse_proteins_from_all() when no connection is made to CAZy."""
+
+    def mock_get_page(*args, **kwargs):
+        return None, "error message"
+
+    monkeypatch.setattr(crawler, "get_page", mock_get_page)
+
+    crawler.parse_proteins_from_all(
+        "page_url",
+        "GH147",
+        None,
+        "session",
+        args_subfam_true["args"],
+    )
+
+
+def test_parse_proteins_from_all_successfully(monkeypatch, args_subfam_true, gh147_page):
+    """Test parse_proteins_from_all() when successful."""
+
+    with open(gh147_page) as fp:
+        soup = BeautifulSoup(fp, features="lxml")
+
+    def mock_get_page(*args, **kwargs):
+        return soup, None
+
+    def mock_adding_to_db(*args, **kwargs):
+        return {"url": None, "error": None, "sql": None}
+
+    monkeypatch.setattr(crawler, "get_page", mock_get_page)
+    monkeypatch.setattr(sql_interface, "add_protein_to_db", mock_adding_to_db)
+
+    crawler.parse_proteins_from_all(
+        "http://www.cazy.org/GH147_all.html",
+        "GH147",
+        None,
+        "session",
+        args_subfam_true['args'],
+    )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -531,7 +531,7 @@ def test_parse_family_no_page_urls(monkeypatch, args):
         return [], 0
 
     monkeypatch.setattr(crawler, "get_page", mock_get_page)
-    monkeypatch.setattr(crawler, "get_protein_page_urls", mock_page_urls)
+    monkeypatch.setattr(crawler, "get_tax_page_urls", mock_page_urls)
 
     test_fam = crawler.Family("GH3", "Glycoside Hydrolases (GHs)", "http://www.cazy.org/GH1.html")
 
@@ -561,7 +561,7 @@ def test_parse_family_success(protein_gen, monkeypatch, args):
         ]
 
     monkeypatch.setattr(crawler, "get_page", mock_get_page)
-    monkeypatch.setattr(crawler, "get_protein_page_urls", mock_page_urls)
+    monkeypatch.setattr(crawler, "get_tax_page_urls", mock_page_urls)
     monkeypatch.setattr(crawler, "parse_proteins", mock_parse_proteins)
 
     test_family = crawler.Family("GH1", "Glycoside Hydrolases (GH)", "www.cazy.org/GH1.html")
@@ -592,7 +592,7 @@ def test_parse_family_sql_url_errors(protein_gen, monkeypatch, args):
         ]
 
     monkeypatch.setattr(crawler, "get_page", mock_get_page)
-    monkeypatch.setattr(crawler, "get_protein_page_urls", mock_page_urls)
+    monkeypatch.setattr(crawler, "get_tax_page_urls", mock_page_urls)
     monkeypatch.setattr(crawler, "parse_proteins", mock_parse_proteins)
 
     test_family = crawler.Family("GH1", "Glycoside Hydrolases (GH)", "www.cazy.org/GH1.html")
@@ -623,7 +623,7 @@ def test_parse_family_previous_failed_pages(protein_gen, monkeypatch, args):
         ]
 
     monkeypatch.setattr(crawler, "get_page", mock_get_page)
-    monkeypatch.setattr(crawler, "get_protein_page_urls", mock_page_urls)
+    monkeypatch.setattr(crawler, "get_tax_page_urls", mock_page_urls)
     monkeypatch.setattr(crawler, "parse_proteins", mock_parse_proteins)
 
     test_family = crawler.Family(
@@ -643,15 +643,15 @@ def test_parse_family_previous_failed_pages(protein_gen, monkeypatch, args):
     )
 
 
-# test get_protein_page_urls()
+# test get_tax_page_urls()
 
 
-def test_get_protein_page_urls_no_links(gh147_page):
-    """Test get_protein_page_urls() on page with no links."""
+def test_get_tax_page_urls_no_links(gh147_page):
+    """Test get_tax_page_urls() on page with no links."""
     with open(gh147_page) as fp:
         soup = BeautifulSoup(fp, features="lxml")
 
-    crawler.get_protein_page_urls(
+    crawler.get_tax_page_urls(
         "http://www.cazy.org/GH147_bacteria.html",
         soup,
         'bacteria',
@@ -660,12 +660,12 @@ def test_get_protein_page_urls_no_links(gh147_page):
     )
 
 
-def test_get_protein_page_urls_no_pag(gh147_page):
-    """Test get_protein_page_urls() on page with no pagination of proteins."""
+def test_get_tax_page_urls_no_pag(gh147_page):
+    """Test get_tax_page_urls() on page with no pagination of proteins."""
     with open(gh147_page) as fp:
         soup = BeautifulSoup(fp, features="lxml")
 
-    crawler.get_protein_page_urls(
+    crawler.get_tax_page_urls(
         "http://www.cazy.org/GH147_bacteria.html",
         soup,
         'bacteria',
@@ -674,12 +674,12 @@ def test_get_protein_page_urls_no_pag(gh147_page):
     )
 
 
-def test_get_protein_page_urls_page(pag_page):
-    """Test get_protein_page_urls() on page with pagination of proteins."""
+def test_get_tax_page_urls_page(pag_page):
+    """Test get_tax_page_urls() on page with pagination of proteins."""
     with open(pag_page) as fp:
         soup = BeautifulSoup(fp, features="lxml")
 
-    crawler.get_protein_page_urls(
+    crawler.get_tax_page_urls(
         "http://www.cazy.org/GH1_bacteria.html",
         soup,
         'bacteria',


### PR DESCRIPTION
The Kingdom HTML tables only contain 100 proteins per table. As a consequence, the time required to scrape all of CAZy is significantly increased.

To avoid this, if no Kingdoms are specified proteins are retrieved from the HTML tables stored under the 'all' tab for each CAZy family.