### PR TITLE
Tidy docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -21,8 +21,8 @@ by simply calling the scraper at the command line in the terminal:
 .. code-block:: bash
   python3 <path_to_cazy_webscraper.py_file>
 
-The `cazy_webscraper.py` file is located within the directory `scraper`. Therefore, if the terminal 
-is already pointing at the `scraper` directory, the command to invoke ``cazy_webscraper`` is:
+The ``cazy_webscraper.py`` file is located within the directory ``scraper``. Therefore, if the terminal 
+is already pointing at the ``scraper`` directory, the command to invoke ``cazy_webscraper`` is:
 
 .. code-block:: bash
   python3 cazy_webscraper.py
@@ -266,7 +266,7 @@ Configuration when scraping subfamilies
 If any subfamilies are listed within the configuration file, the retrieval of subfamilies **must** 
 be enabled at the command line uisng ``--subfamilies``.
 
-If the parent family, e.g GH3, is listed in the configuration file and `--subfamilies` is enabled, 
+If the parent family, e.g GH3, is listed in the configuration file and ``--subfamilies`` is enabled, 
 all proteins catalogued under GH3 and its subfamilies will be retrieved. This is to save time 
 having to write out all the subfamilies for a given CAZy family. The scraper will remove any 
 duplicate proteins automatically.
@@ -275,11 +275,11 @@ duplicate proteins automatically.
 An example configuration file
 -----------------------------
 
-A blank configuration file is packaged within `cazy_webscraper`, within the `scraper` directory, 
-called `scraper_config.yaml`. This configuration file contains comments to assit filling in the 
+A blank configuration file is packaged within ``cazy_webscraper``, within the ``scraper`` directory, 
+called ``scraper_config.yaml``. This configuration file contains comments to assit filling in the 
 file correctly. A new configuration file with any given name can be created and used. However, 
 it **must** be a Yaml file and it **must** use the same headings/tags as used in the configuration 
-file `scraper_config.yaml`.Please find more information on writing lists in Yaml files 
+file ``scraper_config.yaml``.Please find more information on writing lists in Yaml files 
 [here](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html).
 
 Below is an example of how the configuration file may look.

--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -1,0 +1,44 @@
+============================
+``cazy_webscraper`` Database
+============================
+
+To facilitate thorough interrogation of data retrieved from CAZy, minimise storing duplicate and redundant data, data retrieved from CAZy is stored in a local SQL database. Every CAZyme scraped from CAZy has the following data:
+
+- Protein name
+- CAZy (sub)family
+- GenBank accession(s)
+
+Each CAZyme may or may not have the following data, depending on the entry:
+
+- EC number(s)
+- UniProt acession(s)
+- PDB accession(s)
+
+------------------------------------------
+Primary and non-primary GenBank accessions
+------------------------------------------
+
+Multiple GenBank accession numbers may be listed for a single CAZyme record at CAZy. CAZy records the "best model" for each CAZyme in bold (see `here for details <http://www.cazy.org/Help.html>`_). The bold accession is interpreted by ``cazy_webscraper`` as the **primary GenBank accession**. Where multiple GenBank accessions are written in bold, only the _first_ listed bold GenBank accession is listed as the **primary GenBank accession**. All other listed GenBank accessions are listed as **non-primary GenBank accessions**.
+
+Each CAZyme in the local SQLite3 database is identified uniquely by its **primary GenBank accession**. If a CAZyme is associated with multiple families, it is represented as a single CAZyme record in the local SQLite database.
+
+.. NOTE::
+    GenBank protein sequences are not recorded in the local SQLite3 database. They are written to disk in a user-specified directory.
+
+------------------------------------------
+Primary and non-primary UniProt accessions
+------------------------------------------
+
+Multiple UniProt accessions may be listed for a single CAZyme record at CAZy. ``cazy_webscraper`` records accessions listed in bold as "**primary UniProt accessions**", and other accessions as **non-primary UniProt accessions** in the local database. 
+
+--------------
+PDB accessions
+--------------
+
+All PDB accessions associated with a CAZyme record at CAZy are recorded in the local SQLite3 database, and no differentiation is made between primary and non-primary accessions.
+
+.. NOTE::
+    Not all PDB accessions represented in a CAZyme record at CAZy are necessarily present in PDB. For example, some accessions are placeholders while structures are under embargo.
+
+.. NOTE::
+    PDB/RCSB protein structures are not recorded in the local SQLite3 database. They are written to disk in a user-specified directory.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,7 +75,7 @@ For details and updates on development, please consult the `GitHub repository <h
    :maxdepth: 2
    
    installation
-   configuration
+   usage
    tutorial
    database
    genbank

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Welcome to cazy_webscraper's documentation!
    :alt: cazy_webscraper logo, host organisations and funding
    :align: center
 
-| For all the latest updates, and development progress make sure to check the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_
+| For latest updates and development progress, please check the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_
 
 -----------------
 Build Information
@@ -64,7 +64,7 @@ Build Information
 
    Hobbs, Emma E. M.; Pritchard, Leighton; Chapman, Sean; Gloster, Tracey M. (2021): cazy_webscraper Microbiology Society Annual Conference 2021 poster. figshare. Poster. https://doi.org/10.6084/m9.figshare.14370860.v7 
 
-``cazy_webscraper`` retrieves data from CAZy, writing it to a local SQLite3 file. ``cazy_webscraper`` can retrieve the protein sequences from NCBI, for CAZymes in the local database, and also write out those sequences in FASTA format. Additionally, ``cazy_webscraper`` can retrieve protein structures from the Research Collaboratory for Structural Bioinformatics (RCSB) Protein Data Bank, `PDB <https://www.rcsb.org/>`_, for CAZymes in the local database.
+``cazy_webscraper`` retrieves data from CAZy, writing it to a local SQLite3 file. ``cazy_webscraper`` can retrieve the protein sequences from NCBI for CAZymes in the local database, and also write out those sequences in FASTA format. Additionally, ``cazy_webscraper`` can retrieve protein structures from the Research Collaboratory for Structural Bioinformatics (RCSB) Protein Data Bank, `PDB <https://www.rcsb.org/>`_, for CAZymes in the local database.
 
 ``cazy_webscraper`` can be configured to scrape the entire CAZy database, to recover only CAZymes filtered by user-supplied criteria, such as CAZy classes, CAZy (sub)family, or taxonomy. 
 
@@ -81,7 +81,7 @@ Quickstart
 Best practice
 -------------
 
-When performing a series of many, automated, repeated calls to a server it is polite to do this when internet traffic is lowest *at the server*. This is typically at the weekend and overnight.
+When performing a series of many automated, repeated calls to a server it is polite to do this when internet traffic is lowest *at the server*. This is typically at the weekend and overnight.
 
 The webscraper can appear to run slowly but this may be due to the bandwidth at the CAZy server, or server speed. ``cazy_webscraper`` provides a progress bar to reassure the user that the webscraper is working. 
 
@@ -110,7 +110,7 @@ For details and updates on development, please consult the `GitHub repository <h
 Citing ``cazy_webscraper``
 --------------------------
  
-If you use ``cazy_webscraper`` in your work *please* do cite our work (including the provided DOI), as well as the specific version of the tool you use. This is not only helpful for us as developers to get out work out into the world, but it is also **essential for the reproducibility and integrity of scientific research**. Citation:
+If you use ``cazy_webscraper`` in your work *please* do cite our work (including the provided DOI), as well as the specific version of the tool you use. This is not only helpful for us as developers to get our work out into the world, but it is also **essential for the reproducibility and integrity of scientific research**. Citation:
    
    Hobbs, Emma E. M.; Pritchard, Leighton; Chapman, Sean; Gloster, Tracey M. (2021): cazy_webscraper Microbiology Society Annual Conference 2021 poster. FigShare. Poster. https://doi.org/10.6084/m9.figshare.14370860.v7 
 
@@ -119,6 +119,6 @@ If you use ``cazy_webscraper`` in your work *please* do cite our work (including
 Development and issues
 ----------------------
 
-If there are additional features you wish to be added, you have problems with the scraper, or want to contribute please raise an issue at the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_.
+If there are additional features you wish to be added, you have problems with the scraper, or would like to contribute please raise an issue at the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_.
 
 * Issues Page: `https://github.com/HobnobMancer/cazy_webscraper/issues <https://github.com/HobnobMancer/cazy_webscraper/issues>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,10 @@ Welcome to cazy_webscraper's documentation!
 
 | For all the latest updates, and development progress make sure to check the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_
 
+-----------------
+Build Information
+-----------------
+
 .. image:: https://img.shields.io/badge/Version-v1.0.2-yellowgreen
    :target: https://github.com/HobnobMancer/cazy_webscraper
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4300858.svg
@@ -28,14 +32,33 @@ Welcome to cazy_webscraper's documentation!
    :target: https://www.python.org/about/
 .. image:: https://img.shields.io/badge/Bioinformatics-EASTBio-ff69b4
    :target: http://www.eastscotbiodtp.ac.uk/eastbio-student-cohort-2019
-.. image:: https://img.shields.io/badge/BIOCONDA-integration-brightgreen
-   :target: https://bioconda.github.io/user/install.html
-.. image:: https://img.shields.io/conda/dn/bioconda/cazy_webscraper?label=Bioconda%20downloads
-   :target: https://bioconda.github.io/user/install.html
-.. image:: https://img.shields.io/badge/Pypi-integration-brightgreen
-   :target: https://pypi.org/project/cazy-webscraper/
+
+
+--------
+``PyPI``
+--------
+
+.. image:: https://img.shields.io/pypi/v/cazy_webscraper.svg?style=flat-square
+    :target: https://pypi.python.org/pypi/cazy_webscraper
 .. image:: https://img.shields.io/pypi/dm/cazy_webscraper?label=Pypi%20downloads
    :target: https://pypi.org/project/cazy-webscraper/
+
+------------
+``bioconda``
+------------
+
+.. image:: https://anaconda.org/bioconda/cazy_webscraper/badges/installer/conda.svg?style=flat-square
+     :target: https://conda.anaconda.org/bioconda
+.. image:: https://anaconda.org/bioconda/cazy_webscraper/badges/version.svg?style=flat-square
+    :target: https://anaconda.org/bioconda/cazy_webscraper
+.. image:: https://anaconda.org/bioconda/cazy_webscraper/badges/latest_release_date.svg?style=flat-square
+     :target: https://anaconda.org/bioconda/cazy_webscraper
+.. image:: https://img.shields.io/conda/dn/bioconda/cazy_webscraper?label=Bioconda%20downloads
+   :target: https://bioconda.github.io/user/install.html
+
+-------------------
+``cazy_webscraper``
+-------------------
 
 ``cazy_webscraper`` is a Python3 package for the automated retrieval of carbohydrate-active enzyme (CAZyme) data from the `CAZy <http://wwww.cazy.org/>`_ database. This program is free to use under the MIT license, and we kindly request that, if you use this program or Python package, you cite it as indicated below.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ For details and updates on development, please consult the `GitHub repository <h
    installation
    configuration
    tutorial
+   database
    genbank
    pdb
    license
@@ -91,82 +92,10 @@ If you use ``cazy_webscraper`` in your work *please* do cite our work (including
    Hobbs, Emma E. M.; Pritchard, Leighton; Chapman, Sean; Gloster, Tracey M. (2021): cazy_webscraper Microbiology Society Annual Conference 2021 poster. FigShare. Poster. https://doi.org/10.6084/m9.figshare.14370860.v7 
 
 
-Output
-------
-
-Database
-========
-
-To facilitate thorough interrogation of data retrieved from CAZy, minimise storing duplicate and redundant data, data retrieved from CAZy is stored in a local SQL database. Every CAZyme scraped from CAZy has the following data:
-
-- Protein name
-- CAZy (sub)family
-- GenBank accession(s)
-
-Each CAZyme may or may not have the following data, depending on the entry:
-
-- EC number(s)
-- UniProt acession(s)
-- PDB accession(s)
-
-Primary and non-primary GenBank accessions
-==========================================
-
-Multiple GenBank accession numbers may be listed for a single CAZyme at CAZy. CAZy writes the "best model" in bold, see `here for details <http://www.cazy.org/Help.html>`_. This is interpreted by ``cazy_webscraper`` as the **primary GenBank accession**. Where multiple GenBank accessions are written in bold, only the first listed bold GenBank accession is listed as the **primary GenBank accession**. All other listed GenBank accessions are listed as **non-primary GenBank accessions**.
-
-Each CAZyme scraped from CAZy is identified uniquely by its **primary GenBank accession**. Even if a CAZyme is associated with multiple families, it is stored as a single CAZyme record in the local SQLite database.
-
-Primary and non-primary UniProt accessions
-==========================================
-
-If multiple UniProt accessions are listed for a CAZyme, all accessions written in bold are treated by ``cazy_webscraper`` as the 'best' model. All UniProt accessions listed in bold are defined as **primary UniProt accessions**, and all other accessions are listed as **non-primary UniProt accessions**. 
-
-PDB accessions
-==============
-
-All PDB accessions associated with a CAZyme are considered equal, and no differentiation is made between primary and non-primary accessions.
-
-**NOTE:** not all PDB accessions listed in CAZy are present in PDB. 
-
-Protein sequences
-=================
-
-If enabled, the protein sequence of each scraped CAZyme is retrieved from GenBank in FASTA format.
-
-Protein structures
-==================
-
-If requested, protein structures are written out to disk in a user-specified directory.
-
-
-Quick Start
---------------
-
-To invoke the webscraper with its default functionality call the webscraper at the command line:  
-
-.. code-block:: bash
-
-  cazy_webscraper 
-
-The default behaviour of the scraper is:
-
-* Scrape all entries in the CAZy database
-* Do not split/separate the data: produce a single output
-* Write the resulting data to STDOUT
-* Do not retrieve subfamilies (subfamily members will be retrieved but only their parent family be listed)
-* Do not retrieve FASTA files from GenBank
-* Do not retrieve protein sequences from PDB
-
-
-Configuration
---------------
-
-The scraping of CAZy is entirely configurable to suit your purpose. Entire classes and/or specific families can be scraped, and the ability to scrape subfamilies can be enabled or disabled.
-
-For more details see the configuration section of the documetation.
-
-
+----------------------
 Development and issues
------------------------
+----------------------
 
-If there are additional features you wish to be added, you have problems with the scraper, or want to contribute please raise an issue at the GitHub repository.
+If there are additional features you wish to be added, you have problems with the scraper, or want to contribute please raise an issue at the `GitHub repository <https://github.com/HobnobMancer/cazy_webscraper>`_.
+
+* Issues Page: `https://github.com/HobnobMancer/cazy_webscraper/issues <https://github.com/HobnobMancer/cazy_webscraper/issues>`_

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 ============
 Installation
 ============

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,266 +1,127 @@
-================================================================
-How to install ``cazy_webscraper``
-================================================================
+============
+Installation
+============
 
-This page includes a step-by-step guide on installing ``cazy_webscraper``, including checking your computer setup meets the requirements to install ``cazy_webscraper``, and 3 different ways to install ``cazy_webscraper``. 
+We support three ways to install ``cazy_webscraper``.
 
-If you are experienced using ``pip`` and ``bioconda`` to install Python packages, jump down to the relevant sections to get the command to install the packages.
+* Using `bioconda <https://bioconda.github.io/>`_ **[Recommended]**
+* Using `pip/PyPI <https://pypi.python.org/pypi/cazy_webscraper>`_
+* Installation from source (`git clone <https://github.com/cazy-project/cazy_webscraper>`_)
 
-If you are not experienced with installing programs via the command-line then read on!
+------------
+Requirements
+------------
 
+* a POSIX-compliant operating system, e.g. macOS or Linux.
+* Python 3.8 or later
+* an internet connection (to access CAZy and download data)
 
-Checking the requirements
-****************************
+----------------------------
+Installing with ``Bioconda``
+----------------------------
 
-To use ``cazy_webscraper`` you need to be using a POISx operating system (OS), Mac OS or a Linux emulator. This is because 
-you need access to a Unix shell (a form of command-line) that writes in a language called Bash.
+.. TIP::
+   The most recent stable release of ``cazy_webscraper`` should always be avaiable from the ``bioconda`` channel.
 
-Linux
-========
-POISx includes operating systems such as Unix and it derivaties, Linux, and its derivatives such as Ubuntu. On Linux 
-OS the default Unix shell is Bash.
-
-Mac
-=======
-If you are working on a Mac then you already have a Unix shell program installed.
-
-Mac OS Mojave or earlier releases
--------------------------------------
-
-If you are running a Mac computer running Mac OS Mojave or earlier releases, the default Unix shell is using Bash. To access 
-the Unix shell (or terminal) try one of the following:
-
-* In Finder, select the Go menu, then select Utilities. Locate Terminal in the Utilities folder and open it
-* Use the Mac ‘Spotlight’ computer search function. Search for: Terminal and press Return
-
-To check if your machine is set up to use something other than Bash, type ``echo $SHELL`` in your terminal window.
-
-Mac OS Catalina or later releases
--------------------------------------
-
-For a Mac computer running macOS Catalina or later releases, or if you computer is set up to use something other 
-than Bash, you can run Bash by opening a terminal, typing the command ``bash`` and hitting return.
-
-Windows
-===========
-
-If you use Windows you can use a Linux emulator. Several emulators exist. Here we'll run through two different emulators you could use, 
-and how to install them. These are not the only two and feel free to use which ever Linux emulator you wish!
-
-Ubuntu
----------
-
-Another Linux emulator that you can run on Windows is provided by Ubuntu. Ubuntu is a version of Linux with a graphical 
-user interface (GUI), and they also provide a Windows emulator version that is fully supported, free and available via the `Microsoft app store <https://www.microsoft.com/en-gb/p/ubuntu-2004-lts/9n6svws3rx71#activetab=pivot:overviewtab>`_.
-
-To install the Ubuntu emulator, navigate the `Microsoft store page <https://www.microsoft.com/en-gb/p/ubuntu-2004-lts/9n6svws3rx71#activetab=pivot:overviewtab>`_, and click install. 
-This will handel all installation for you.
-
-To start the terminal, open the Windows Start Menu and type 'Ubuntu', this will find the Ubuntu program. Click on Ubuntu and this will open a Ubuntu terminal. 
-
-Ubuntu sets the Home as its own set of directories. To navigate to any hardrive in your system, open the Ubuntu terminal then type:  
-``cd /mnt/<letter_of_harddrive (in lower case)>``, for example to access the C drive you would use ``cd /mnt/c``. The ``/mnt`` prefix 
-accesses the Windows 'mounting' system, which is how it accesses harddrives within the computer.
-
-Git for Windows
------------------
-
-One Linux emulator you can use if included in *Git for Windows*. The following installation instructions are adapted from 
-Software Carpentry `lessons <https://carpentries.github.io/workshop-template/#shell>`_. You can find a video tutorial with a step-by-step guide `here <https://youtu.be/339AEqk9c-8>`_.
-
-Installation instrucitions:
-* Download the Git for Windows install from `here <https://gitforwindows.org/>`_.
-* Run the installer
-* Click the "Next" button four times (only two times if you already have Git installed). *You do not need to change anything the Information, location, components, and start menu screens.
-* From the dropdown menu select "Use the Nano editor by default" (NOTE: you will need to scroll up to find it) and click "Next"
-* On the page that says "Adjusting the name of the initial branch in new repositories", ensure that "Let Git decide" is selected.
-* Ensure that "Git from the command line and also from 3rd-party software" is selected and click on "Next"
-* Ensure that "Use the native Windows Secure Channel Library" is selected and click on "Next".
-* Ensure that "Checkout Windows-style, commit Unix-style line endings" is selected and click on "Next".
-* Ensure that "Use Windows' default console window" is selected and click on "Next".
-* Ensure that "Default (fast-forward or merge) is selected and click "Next"
-* Ensure that "Git Credential Manager Core" is selected and click on "Next".
-* Ensure that "Enable file system caching" is selected and click on "Next".
-* Click on "Install".
-* Click on "Finish" or "Next".
-* If your "HOME" environment variable is not set (or you don't know what this is):
-* Open command prompt (Open the Windows Start Menu, then type 'cmd', and press Enter). Wait for the command promt window to open, and type the following line into the command prompt window exactly as shown:
-``setx HOME "%USERPROFILE%"``. Press Enter, you should see ``SUCCESS: Specified value was saved``. Quit command prompt by typing `exit` then pressing Enter
-
-
-The shell terminal
-*********************
-For more information on using the Unix shell checkout the content and lessons hosted at `SoftWare Carpentry <https://swcarpentry.github.io/shell-novice/01-intro/index.html>`_, which 
-will walk through an introduction to the Unix shell and how the Unix shell can be used to optimise computational work.
-
-
-Installing cazy_webscraper
-******************************
-
-There are three different ways to install ``cazy_webscraper``:  
-
-* Via ``Bioconda``
-* Via ``pip``
-* From the source repository
-
-Installing via ``Bioconda`` and ``pip` are by far the easiest methods of installation. Installing from source is not necessarily more difficult, but it takes a couple more steps.
-
-Installing via ``Bioconda``
-==============================
-
-``cazy_webscraper`` can be installed via ``bioconda``. The latest release of ``cazy_webscraper` should always be avaiable from the ``bioconda`` channel.
-
-If you already have `conda` installed *and* the ``bioconda`` channel available, ``cazy_webscraper`` can be fully installed using the command:  
-
-.. code-block:: bash
-
-   conda install cazy_webscraper
-
-If you do not have the `bioconda` channel available (you may discover this when trying to use the above command and the computer throws up the message ``PackagesNotFoundError: The following packages are not available from current channels``), you can install ``cazy_webscraper`` using the command:  
+To install ``cazy_webscraper`` using `bioconda <https://bioconda.github.io/>`_ and all required packages, you can use the following command:
 
 .. code-block:: bash
 
    conda install -c bioconda cazy_webscraper
 
-If Conda is not installed, please see the Conda website for installation `instructions <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_.
+.. NOTE::
+   If ``conda`` is not installed on your system, please see the ``conda`` website for `instructions <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_.
 
-.. warning::
-   If you install ``cazy_webscraper`` via ``bioconda``, to invoke ``cazy_webscraper`` call it via the command-line using ``cazy_webscraper``.
+----------------------------
+Installing with ``pip``/PyPI
+----------------------------
 
-Installing via ``pip``
-==============================
+.. TIP::
+   The most recent stable release of ``cazy_webscraper`` should always be avaiable from ``PyPI``.
 
-``cazy_webscraper`` can also be installed via the `Python package index (Pypi)s <https://pypi.org/project/cazy-webscraper/>`_. To install ``cazy_webscraper`` use the command:  
-
-.. code-block:: bash
-
-   pip3 install cazy-webscraper
-
-Now ``cazy_webscraper`` is fully installed and you can skip to the part of the tutorial that explains how to use it!
-
-If ``pip`` is not installed, text will appear in the terminal telling you how to use `pip`. If `pip` is not install an error message will be displayed, stating that the computer could not find a command called `pip`. If this happens install pip using:  
+To install ``cazy_webscraper`` and all required packages using `pip <https://pypi.python.org/pypi/cazy_webscraper>`_, you can use the following command:
 
 .. code-block:: bash
-   
-   python get-pip.py
 
-To update the version of `pip` install on your computer use:  
+   python -m pip install cazy-webscraper
 
+----------------------
+Installing from source
+----------------------
 
-.. code-block:: bash
-   
-   python -m pip install --upgrade pip
- 
- Then you should be able to install ``cazy_webscraper`` using the command provided above.
- 
-.. warning::
-   If you install ``cazy_webscraper`` via ``pip``, to invoke ``cazy_webscraper`` call it via the command-line using ``cazy_webscraper``.
+``cazy_webscraper`` can be installed from the source code available at the `GitHub repository <https://github.com/cazy-project/cazy_webscraper>`_.
 
- 
- 
-Installing from source: Installing using the files stored in the GitHub repository
-====================================================================================
+.. WARNING::
+   The ``cazy_webscraper`` repository provides the development version of ``cazy_webscraper``. This is the version that is most recently updated, but it may not be the latest stable version. In particular, the development version may contain features that are not yet in a stable version, and it may contain bugs.
 
+.. TIP::
+   To obtain the most recent _stable_ source code from the ``cazy_webscraper`` repository, download a release from the `releases page <https://github.com/cazy-project/cazy_webscraper/releases>`_ and extract the archive.
 
-You can install ``cazy_webscraper`` directly from the GitHub repository. Open up your Bash terminal. Then we need to navigate to directory where you want to install ``cazy_webscraper``. To do this we will use the ``cd`` command.
+.. ATTENTION::
+   If you are using `conda`, you can use the ``Makefile`` in the ``cazy_webscraper`` repository to install ``cazy_webscraper`` from source, with the command ``make setup_env``.
 
-Just like how the windows explorer points at a single directory at any time, and shows you the content of the directory, the terminal acts the same way. 
-To check at what directory your terminal is pointed at (or looking at, type the command ``pwd`` and press enter. The terminal will then 
-return the path of the directory at which it is currently looking at. For example, if the terminal is pointed at a directory called 'my_data' within another directory called 'Documents', located on the C drive, 
-``pwd`` will return ``c/Documents/my_dir/``.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Obtaining ``cazy_webscraper`` source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We can change directory using the 'change directory' command (``cd``). Continuing on from the example above, 
-if we wanted to move from the directory 'my_dir' into the directory 'cazyme_research' located within it, and then into 
-the directory 'cazy_dir' within that, we would use the command ``cd cazyme_research/cazy_dir``.
+The **development** version of ``cazy_webscraper`` is available at the `GitHub repository <https://github.com/cazy-project/cazy_webscraper>`_ and can be downloaded in the following ways.
 
-The change directory (``cd``) command is called then provided a path to the directory that we wish to 
-have the terminal pointed at. The ``cd`` command starts at the directory the terminal is currently looking at, then 
-follows the path we provide it. This is why to move from 'my_dir' > 'cazy_research' > 'cazy_dir' we can type 
-``cd cazy_research/cazy_dir``, becuase the terminal will looking within the 'my_dir' directory for the 'cazy_research' directory.
-
-Using the ``cd`` command navigate to the directory you wish to install ``cazy_webscraper``. 
-**If the directory where you wish to install ``cazy_webscraper`` does not exist we can use the terminal to make it**. 
-To use the terminal, first use the ``cd`` comamand to navigate to the parent directory of where you wish to house the 
-directory that you will install ``cazy_webscraper``. Then call the 'make directory command' ``mkdir`` followed by the name 
-you wish to give the directory. For example, once we have navigated to the 'cazy_dir', we can make the directory 
-'cazyme_databases' by using ``mkdir cazyme_database``. We can then navigate into the 'cazyme_database' directory we have justed made 
-by typing ``cd cazy_database`` into the terminal and hitting Return.
-
-**Installing ``cazy_webscraper``**
-
-First we clone the GitHub repository, by using the code:
+To clone the ``cazy_webscraper`` repository using ``git``, you can use the following command:
 
 .. code-block:: bash
 
    git clone https://github.com/HobnobMancer/cazy_webscraper 
 
-This creates a new directory into the directory that the terminal is currently pointed at, called 
-'cazy_webscraper'. The command also downloads all files in the GitHub repository, and writes them into 
-the new 'cazy_webscraper' directory.
+This will download the most recent development version of ``cazy_webscraper`` into a new directory called ``cazy_webscraper``.
 
-We then need to move into the 'cazy_webscraper' directory:
+Alternatively, the **development** version can be downloaded as an archive file from the link below.. button:: 
 
-.. code-block:: bash
+* `source code .zip file <https://github.com/HobnobMancer/cazy_webscraper/archive/refs/heads/master.zip>`_
 
-   cd cazy_webscraper
+This file can be extracted and will create the directory ``cazy_webscraper``.
 
-We then use the Python package manage ``pip`` to install ``cazy_webscraper``.
+^^^^^^^^^^^^^^^^^
+Required packages
+^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+``cazy_webscraper`` requires several packages to be installed, in order to run. You can install these packages using the ``requirements`` files in the ``cazy_webscraper`` directory. The commands needed depend on your working environment.
 
-   pip3 install -e .
+******************
+Using ``pip``/PyPI
+******************
 
-Do not forget the **-e** from this command, otherwise ``cazy_webscraper`` will not be installed correctly 
-and you will run into constant issues when trying to use ``cazy_webscraper``.
-
-**If you ever invoke ``cazy_webscraper`` and want to cancle the command, simple press the ``Ctrl`` and ``c`` keys at the same time.**
-
-.. warning::
-   If you install ``cazy_webscraper`` from source, to invoke ``cazy_webscraper`` you will need call Python3 followed by the path to the ``cazy_webscraper.py`` file. For example, if you are located in the root directory of the respository, you would use:  ``pyathon3 scraper/cazy_webscraper.py``.
-
-Checking the installation
-****************************
-
-To check ``cazy_webscraper`` was installed correctly, use the command:
+All third-party packages can be installed using ``pip``/PyPI:
 
 .. code-block:: bash
 
-   cazy_webscraper -h
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt  # only needed if you are developing the code
+   pip install -r requirements-pip.txt  # only needed if you are developing the code
 
-If ``cazy_webscraper`` is installed corretly, ``cazy_webscraper`` will install its help message, which should look something like the following:
+***************
+Using ``conda``
+***************
+
+The ``conda`` package manager can be used to install all required packages for running ``cazy_webscraper``, but the ``sphinx`` package is not available in ``conda`` and must be installed using ``pip``:
 
 .. code-block:: bash
-   (cazy_scraper_env) user@YourComputer:home/python_packages/cazy_webscraper$ cazy_webscraper -h
-   usage: cazy_webscraper.py [-h] [-c config file] [--classes CLASSES] [--cazy_synonyms CAZY_SYNONYMS]
-   [-d local database path] [--ec EC] [-f] [--families FAMILIES] [--genera GENERA]
-   [--get_pages] [--kingdoms KINGDOMS] [-l log file name] [-n] [-o output file name]
-   [-r RETRIES] [--scrape_files SCRAPE_FILES] [-s] [--species SPECIES] [--strains STRAINS]
-   [--streamline STREAMLINE] [-t TIMEOUT] [-v]
-   Scrapes the CAZy database
-   optional arguments:
-   -h, --help            show this help message and exit
-   -c config file, --config config file Path to configuration file. Default: None, scrapes entire database (default: None)
-   --classes CLASSES     Classes from which all families are to be scraped. Separate classes by ',' (default: None)
-   --cazy_synonyms CAZY_SYNONYMS   Path to JSON file containing CAZy class synoymn names (default: None)
-   -d local database path, --database local database path    path to an existing local CAZy SQL database (default: None)
-   --ec EC   Defines EC numbers to restrict the scrape to (default: None)
-   -f, --force   Force file over writting (default: False)
-   --families FAMILIES   Families to scrape. Separate families by commas 'GH1,GH2' (case sensitive) (default: None)  
-   --genera GENERA       Genera to restrict the scrape to (default: None)   
-   --get_pages           Retrieve pages from CAZy and write out HTML files to disk (default: False)     
-   --kingdoms KINGDOMS   Kingdoms to scrape. Separate by a single comma. Options= archaea, bacteria, eukaryota,
-                         viruses, unclassified (not case sensitive) (default: None)
-   -l log file name, --log log file name      Defines log file name and/or path (default: None) 
-   -n, --nodelete        enable/disable deletion of exisiting files (default: False)  
-   -o output file name, --output output file name     Output filename (default: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>)
-   -r RETRIES, --retries RETRIES      Number of times to retry scraping a family or class page if error encountered (default: 10)
-   --scrape_files SCRAPE_FILES        dir containing HTML files of CAZy webpages (default: None)  
-   -s, --subfamilies     Enable retrieval of subfamilies from CAZy (default: False)   
-   --species SPECIES     Species (written as Genus Species) to restrict the scrape to (default: None)     
-   --strains STRAINS     Specific strains of organisms to restrict the scrape to (written as Genus Species Strain)  
-                         (default: None)
-   --streamline STREAMLINE       Define attributes to presume are identical each family HTML table a protein appears in
-                                 The options as: genbank, ec, uniprot, pdb Any combination can be provided.
-                                 GenBank refers to non-primary GenBank accessions. (default: None)
-   -t TIMEOUT, --timeout TIMEOUT          Connection timeout limit (seconds) (default: 45)  
-   -v, --verbose         Set logger level to 'INFO' (default: False)
+
+   conda install --file requirements.txt
+   conda install --file requirements-dev.txt  # only needed if you are developing the code
+   pip install -r requirements-pip.txt        # only needed if you are developing the code
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing ``cazy_webscraper``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``cazy_webscraper`` package can be installed from source using the following command, issued from the root directory of the ``cazy_webscraper`` repository:
+
+.. code-block:: bash
+
+   python setup.py install
+
+If you are intending to edit or develop the code, you can use the ``develop`` option instead of ``install``:
+
+.. code-block:: bash
+
+   pip install -e .

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -42,16 +42,15 @@ For a quick summary of how to get started, check out our poster:
 Default Usage
 -------------
 
-To invoke the webscraper with its default functionality call the webscraper at the command line:  
+To invoke the webscraper and get basic help, call the webscraper at the command line:  
 
 .. code-block:: bash
 
-  cazy_webscraper 
+  cazy_webscraper -h
 
 The default behaviour of the scraper is:
 
 * Scrape all entries in the CAZy database
-* Do not split/separate the data: produce a single output
 * Write the resulting data to STDOUT
 * Do not retrieve subfamilies (subfamily members will be retrieved but only their parent family be listed)
 * Do not retrieve FASTA files from GenBank

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -38,9 +38,9 @@ For a quick summary of how to get started, check out our poster:
 
     Hobbs, Emma E. M.; Pritchard, Leighton; Gloster, Tracey M.; Chapman, Sean (2021): cazy_webscraper - getting started. FigShare. Poster. `https://doi.org/10.6084/m9.figshare.14370869.v3 <https://doi.org/10.6084/m9.figshare.14370869.v3>`_ 
 
--------------
-Default Usage
--------------
+-----------------------------------
+Getting Help From `cazy_webscraper`
+-----------------------------------
 
 To invoke the webscraper and get basic help, call the webscraper at the command line:  
 
@@ -55,3 +55,15 @@ The default behaviour of the scraper is:
 * Do not retrieve subfamilies (subfamily members will be retrieved but only their parent family be listed)
 * Do not retrieve FASTA files from GenBank
 * Do not retrieve protein sequences from PDB
+
+-------------------------
+Downloading a CAZy Family
+-------------------------
+
+To download the single CAZy family GH169, use the command:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 -o GH169
+
+This will create a new directory ``GH169`` in the current working directory, and will download all CAZy entries in the GH169 family to a new SQLite3 database in that directory:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -37,3 +37,22 @@ Getting Started Poster
 For a quick summary of how to get started, check out our poster:
 
     Hobbs, Emma E. M.; Pritchard, Leighton; Gloster, Tracey M.; Chapman, Sean (2021): cazy_webscraper - getting started. FigShare. Poster. `https://doi.org/10.6084/m9.figshare.14370869.v3 <https://doi.org/10.6084/m9.figshare.14370869.v3>`_ 
+
+-------------
+Default Usage
+-------------
+
+To invoke the webscraper with its default functionality call the webscraper at the command line:  
+
+.. code-block:: bash
+
+  cazy_webscraper 
+
+The default behaviour of the scraper is:
+
+* Scrape all entries in the CAZy database
+* Do not split/separate the data: produce a single output
+* Write the resulting data to STDOUT
+* Do not retrieve subfamilies (subfamily members will be retrieved but only their parent family be listed)
+* Do not retrieve FASTA files from GenBank
+* Do not retrieve protein sequences from PDB

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -63,8 +63,7 @@ The command-line options listed above can be used in any combination to customis
 to restrict which CAZymes are scraped from CAZy are applied in combination. For example, if the ``--families`` option and ``--ec`` option are called then 
 only CAZymes from the specified families **and** annotated with the listed EC numbers will be retrieved.
 
-We will now walk through some examples of how to use ``cazy_webscraper``. All example code provided in this section will presume that the terminal is 
-pointed at the `scraper` directory, which contains the `cazy_webscraper.py` file.
+We will now walk through some examples of how to use ``cazy_webscraper``. All example code provided in this section will presume that the terminal is pointed at the ``scraper`` directory, which contains the ``cazy_webscraper.py`` file.
 
 .. note::
    **For those new to using command-line tools: flags**
@@ -789,7 +788,7 @@ If a CAZyme is not part of a subfamily only its CAZy family annotations will be 
 If any subfamilies are listed within the configuration file, the retrieval of subfamilies **must** 
 be enabled at the command line uisng ``--subfamilies``.
 
-If the parent family, e.g GH3, is listed in the configuration file and `--subfamilies` is enabled, 
+If the parent family, e.g GH3, is listed in the configuration file and ``--subfamilies`` is enabled, 
 all proteins catalogued under GH3 and its subfamilies will be retrieved. This is to save time 
 having to write out all the subfamilies for a given CAZy family. The scraper will remove any 
 duplicate proteins automatically.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -16,9 +16,6 @@ To download the single CAZy family GH169, use the command:
 
 This will create a new directory ``GH169`` in the current working directory, and will download all CAZy entries in the GH169 family to a new SQLite3 database in that directory.
 
-.. NOTE::
-  ``cazy_webscraper`` input options can also be specified in a **YAML configuration file**, to enable transparency and reproducibility.
-
 This page provides a brief summary of command-line options for ``cazy_webscraper`` that control the retrieval of data sets from the CAZy database, including:
 
 * Retrieve only specified CAZy classes and families or subfamilies
@@ -133,19 +130,25 @@ The command-line options listed above can be used in combination to customise th
 Defining CAZy families and classes to scrape
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The 'definition' arguments (e.g. ``--classes`` and ``--families``) are applied singly, e.g.
+The 'definition' arguments (e.g. ``--classes`` and ``--families``) indicate which groups of data will be selected for scraping from CAZy, e.g.
 
 .. code-block:: bash
 
   cazy_webscraper --families GH169 -o GH169
   cazy_webscraper --classes AA -o AA
 
-but more than one class or family can be specified, e.g.
+will download all CAZymes from the GH169 family, and the AA class, respectively. More than one class or family can be specified, e.g.
 
 .. code-block:: bash
 
   cazy_webscraper --families GH169,GH1,GH2,GH3 -o GH_families
   cazy_webscraper --classes AA,CBM -o other_classes
+
+and members of distinct families and classes can be selected simultaneously, e.g.
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169,GH1,GH2,GH3 --classes AA,CBM -o complex_query
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Filtering CAZy families and classes
@@ -194,37 +197,57 @@ To write output to an existing directory without deleting the content already pr
   cazy_webscraper --families GH169 -d GH169_output -f -n
 
 
-Configuration via a YAML file
-------------------------------
+.. NOTE::
+  ``cazy_webscraper`` input options can also be specified in a **YAML configuration file**, to enable transparency and reproducibility.
 
-Using a configuration files produces reproducible documentation of how you used ``cazy_webscraper`` -- which is an essential part of all bioinformatic research.
+-------------------------------
+Configuration using a YAML file
+-------------------------------
 
-An example/template YAML file is provided within the repository of the webscraper, located at: 
-``./scraper/scraper_config.yaml``. A configuration YAML file must contain the same tags/headings as 
-the example configuration file found in the repository. The headings are:
+All command-line options to control CAZy scraping can be provided instead *via* a YAML configuration file. This supports reproducible documentation of ``cazy_webscraper`` usage.
 
-* classes
-* Glycoside Hydrolases (GHs)
-* GlycosylTransferases (GTs)
-* Polysaccharide Lyases (PLs)
-* Carbohydrate Esterases (CEs)
-* Auxiliary Activities (AAs)
-* Carbohydrate-Binding Modules (CBMs)
-* genera
-* species
-* strains
-* kingoms
+An template YAML file is provided in the ``cazy_webscraper`` repository (``scraper/scraper_config.yaml``):
+
+.. code-block:: yaml
+
+  # Under 'classes' list class from which all proteins will retrieved
+  # Under each families respective name, list the specific families/subfamilies to be scraped
+  # Write the FULL family name, e.g. 'GH1', NOT only its number, e.g. '1'
+  # To list multiple families, each familiy must be on a new line starting indented once
+  # relative to the parent class name, and the name written within quotation marks.
+  # For more information on writing lists in Yaml please see:
+  # https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html 
+  classes:  # classes from which all proteins will be retrieved
+  Glycoside Hydrolases (GHs):
+  GlycosylTransferases (GTs):
+  Polysaccharide Lyases (PLs):
+    - "PL28"
+  Carbohydrate Esterases (CEs):
+  Auxiliary Activities (AAs):
+  Carbohydrate-Binding Modules (CBMs):
+  genera:  # list genera to be scraped
+   - "Trichoderma"
+  species:  # list species, this will scrape all strains under the species
+  strains:  # list specific strains to be scraped
+  kingdoms:  # Archaea, Bacteria, Eukaryota, Viruses, Unclassified
+   - "Bacteria"
+
+.. ATTENTION::
+  The YAML configuration file must contain all tags/headings indicated in the example configuration file found in the repository:
+
+  * classes
+  * Glycoside Hydrolases (GHs)
+  * GlycosylTransferases (GTs)
+  * Polysaccharide Lyases (PLs)
+  * Carbohydrate Esterases (CEs)
+  * Auxiliary Activities (AAs)
+  * Carbohydrate-Binding Modules (CBMs)
+  * genera
+  * species
+  * strains
+  * kingoms
 
 
-Specifying specific classes to scrape
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Under the **classes** heading list any classes to be scrapped. For classes listed under 'classes', 
-all proteins catalogued under that class will be retrieved, **unless** specific families have been 
-listed under the respective classes heading in the configuration file. Then scraping only the 
-specific families takes precident and the entire class is not scraped. _If you believe this should 
-be changed please raise an issue. It is invisioned that very few users would want to simultanious 
-scrape an entire class and also scrape only specific families from that same class._
 
 A ``cazy_dictionary.json`` has been created and packaged within the ``cazy_webscraper`` 
 (the specific location is ``./scraper/file_io/cazy_dictionary.json``, where '.' is the directory 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -2,161 +2,118 @@
 Using ``cazy_webscraper``
 =========================
 
-``cazy_webscraper`` can be configured to retrieve user specified data sets from CAZy. The configuration 
-applies to the retrieval of protein sequences from GenBank and protein structure files from PDB.
+``cazy_webscraper`` can be used to retrieve user-specified data sets from the CAZy database. The ``cazy_webscraper`` application can be invoked _via_ the command line
 
-``cazy_webscraper`` can be configured via the **command line** and/or via a **YAML configuration file**.
+.. NOTE::
+  ``cazy_webscraper`` options can be specified in a **YAML configuration file**, to enable transparency and reproducibility.
 
-This page provides a brief summary of each of the options that can be invoked to configure the scraping of CAZy 
-using ``cazy_webscraper``. We are currently working on writing additional pages that work through examples of how to invoke 
-and combine these options to fully customise the scraping of CAZy.
+This page provides a brief summary of command-line options for ``cazy_webscraper`` that control the retrieval of data sets from the CAZy database, including:
 
+* Retrieve only specified CAZy classes and families or subfamilies
+* Retrieve only CAZymes from taxonomic kingdoms, genera, species, or strains
+* Recover only CAZymes with specified EC numbers
+* Local SQLite3 database path
+* Verbosity level and logging options
 
-Configuration via the command line
------------------------------------
-
-There are no required/positional arguments for the webscraper, therefore the scraper can be enabled 
-by simply calling the scraper at the command line in the terminal: 
-
-.. code-block:: bash
-  python3 <path_to_cazy_webscraper.py_file>
-
-The ``cazy_webscraper.py`` file is located within the directory ``scraper``. Therefore, if the terminal 
-is already pointing at the ``scraper`` directory, the command to invoke ``cazy_webscraper`` is:
-
-.. code-block:: bash
-  python3 cazy_webscraper.py
-
-When optional arguments are provided the default behaviour of the scraper will be performed. 
-The default behaviour is to:
-
-* Scrape the entire CAZy databases
-* Write the resulting database to standard out (STDOUT)
-* Not to retrieve subfamilies (members of subfamilies will be retrieved but only their parent family will be listed)
-
-
-Options configurable at the command line
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following behaviours of the ``cazy_webscraper`` can be configured at the command-line in the terminal:  
-
-* Limit the scraping of CAZy to specific CAZy classes, CAZy families, kingdoms, genuera, species, strains and/or EC numbers.
-* Force writing out the database to a a new or existing directory
-* Write out a log file of the packages operation
-* Not delete content already present in the output directory
-* Enable retrieving subfamilies
-* Enable verbose logging during the operation of the webscraper
-
-
+--------------------
 Command line options
-^^^^^^^^^^^^^^^^^^^^
-
-The below are listed the flags to be called when invoking ``cazy_webscraper`` in order to configure its operations. 
-For example: ``cazy_webscraper -s -v``
-
-..note::
-    If an optional command is not given when calling the webscraper the relative default behaviour 
-    will be performed.
-
-    The short option is the shortened version of the command, and the long option is the long hand 
-    method of writing the command, only one of the other needs be called not both.
-
+--------------------
 
 .. list-table:: Command line options
    :header-rows: 1
 
    * - Short option
      - Long option
-     - How to use
-     - Default behaviour
+     - Action
+     - Default
    * - ``-c``
      - ``--config``
-     - Pass a path to a YAML configuration file, to specify CAZy classes, families, kingdoms, genera, species, strains and EC numbers to scrape.
-     - No path given, therefore, no configuration provided from a YAML file. Scrape all of CAZy unless other command-line options are provided.
+     - path to a YAML configuration file
+     - do not use YAML configuration file
    * -
      - ``--classes``
-     - Define classes from which all families are to be scraped. Separate classes with a single comma (e.g. ``GH,PL``)
-     - No CAZy classes specified for scraping, therefore, scrape all CAZy classes (unless specific families are provided)
+     - define CAZy classes to be retrieved (comma-separated list for multiple classes)
+     - no specified value
    * - ``-d``
      - ``--database``
-     - Path to an existing SQL database produced by ``cazy_webscraper``, this enables adding more data retrieved from CAZy to an existing database.
-     - Build a new database.
+     - path to SQLite3 database
+     - create a new database with default name
    * - 
      - ``--ec``
-     - Specify specific EC numbers so that only CAZymes annotated with these EC numbers are scraped. Separate EC numbers with a single comma (e.g. ``EC1.2.3.4,EC2.3.4.5``)
-     - No EC numbers specified, therefore, retrieve data for CAZymes regardless of their EC number annotations
+     - define EC numbers to filter CAZyme data (comma-separated list for multiple values)
+     - no specified value
    * - ``-f``
      - ``--force``
-     - Forcing writing out to directory that already exists, if specificed as the output directory. Add the option to the command and do not add anything else, for example: ``python3 cazy_webscraper -o my_dir/ -f``.
-     - Force is false, thus if the output directory already exists the output will not be written to it. ``cazy_webscraper`` will raise an error and close.
+     - force overwriting of existing output
+     - do not force overwrite
    * -
      - ``--families``
-     - Define CAZy families to be scraped. Separate families with a single comma (e.g. ``GH1,GH2``). Use the proper CAZy nomenclature for family names (e.g. GH1 not gh1)
-     - No families specified to be scraped at the command line
+     - define CAZy families to be retrieved (comma-separated list for multiple families)
+     - no specified value
    * -
      - ``--genera``
-     - Specify specific genera of source organisms of CAZyme to scrape. Separate multiple genera with a comma (e.g. ``Aspergillus,Trichoderma``)
-     - No genera specified, so scrapes CAZymes from all genera unless other configuration filters are applied.
+     - filter CAZyme data on taxonomic genus (comma-separated list for multiple values)
+     - do not filter on genus
    * - 
      - ``--get_pages``
-     - Retrieve the HTML code from CAZy for the families that match the configuration criteria provided. The HTML pages are written out to the disk as HTML files, to create a local library of CAZy HTML pages.
-     - Do not write out HTML files to disk and instead scrape the protein data from the retrieved HTML pages.
+     - retrieve HTML from CAZy for specified CAZy families and write to disk
+     - do not retrieve HTML to disk
    * - ``-h``
      - ``--help``
-     - Displays all command-line options for the webscraper in the terminal, including defining their default behaviour and required additional information.
-     - Not to display the help information.
+     - display command line options
+     -  
    * - 
      - ``--kingdoms``
-     - Specify specific taxonomic kingdoms to retrieve CAZymes only sourced from organisms from these kingdoms. The available kingdoms are: archaea, bacteria, eukaryota, viruses, unclassified (not case sensitive).
-     - No taxonomic kingdoms provided, therefore scrape from all kingdoms.
+     - filter CAZyme data on taxonomic kingdom (comma-separated list for multiple values)
+     - do not filter on kingdom
    * - ``-l``
      - ``--log``
-     - Enable writing out a log file, logging the operation of the webscraper. Add the option to command followed by desired path of the resulting log file. This the path to the file not the directory to which the log file is to be written.
-     - Not to write out a log file of the webscrapers operation.
+     - path to log file
+     - do not write log file
    * - ``-n``
      - ``--nodelete``
-     - Do not delete content in the already existing output directory, this applies for the dataframe, FASTA and protein structure output directories. Simply add this option to the command.
-     - Nodelete is false, delete the content already presented in the already existent output directories.
+     - do not delete ("clobber") existing output when overwriting
+     - delete existing output when overwriting
    * - ``-o``
      - ``--output`` 
-     - Specify the directory to write the resulting database of CAZymes to. This directory does not already have to exist, if it does not exist ``cazy_webscraper``` will make the directory. Add the option to the command followed by the path to the desired output directory.
-     - Write the output database to standard out.
+     - path to output database
+     - write to STDOUT
    * - ``-r``
      - ``--retries``
-     - Number of times to retry scraping a family or class page if error encountered.
+     - number of times to retry CAZy web requests.
      - 10
    * -
      - ``--scrape_files``
-     - Scrape CAZyme data from local HTML files containing HTML code from CAZy. Pass the path to the directory containing the CAZy HTML files.
-     - Do not scrape from local HTML pages but call directly to CAZy and scrape the HTML code as it is retrieved.
+     - path to local CAZy HTML files; data will be scraped from these files instead of CAZy website
+     - do not use local CAZy HTML files
    * - ``-s``
      - ``--subfamilies``
-     - Enable retrieval of subfamilies. If not enabled then the parent CAZy family will be listed for the relevant CAZymes. Simply add the option to the command.
-     - Do not retrieve the subfamily annotation. Only the parent CAZy family annotation will be added to the database for applicable CAZymes.
+     - define CAZy subfamilies to be retrieved (comma-separated list for multiple families)
+     - no specified value
    * - 
      - ``--species``
-     - Specify specific species to retrieve CAZymes from. Specifying the species will result in CAZymes from all strains of this species being retrieved. To list multiple species, separate them with a comma (e.g. ``Aspergillus niger,Aspergillus fumigatus``).
-     - No specific species specified.
+     - filter CAZyme data on taxonomic species (comma-separated list for multiple values)
+     - do not filter on species
    * - 
      - ``--strains``
-     - Specify specific strains of species to retrieve CAZymes from. To list multiple species, separate them with a comma (e.g. ``Aspergillus niger CBS 513.88,Aspergillus fumigatus Af293``).
-     - No specific species specified.
+     - filter CAZyme data on strain (comma-separated list for multiple values)
+     - do not filter on strain
    * - 
      - ``--streamline``
-     - Specify attributes that are presumed to be the same each time the same CAZyme is parsed from multiple families. The options are: genbank, ec, uniprot and pdb. Any combination can be provided. GenBank refers to non-primary GenBank accessions.
-     - Streamline mode not enabled, therefore, for every every CAZyme record, check all its provided data is catalogued into the database.
+     - override CAZy metadata for each recovered record
+     - do not override CAZy metadata
    * - ``-t``
      - ``--timeout``
-     - Specify how long (in seconds) a connection is tried before it is called as timed out.
+     - wait time before CAZy web connection is considered timed out
      - 45
    * - ``-v``
      - ``--verbose``
-     - Enable verbose logging of the webscraper. This provides more detailed logging of the progress of the webscrapers operation. Simply add the option to the command.
-     - Do not perform verbose logging. Only log if a warning or error is raised.
+     - enable verbose logging and output
+     - standard logging/output level
 
-
-Basic examples of configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------
+Basic Usage
+-----------
 
 The command-line options listed above can be used in any combination to customise the scraping of CAZy. The options that apply a 'filter' 
 to restrict which CAZymes are scraped from CAZy are applied in combination. For example, if the ``--families`` option and ``--ec`` option are called then 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -247,97 +247,32 @@ An template YAML file is provided in the ``cazy_webscraper`` repository (``scrap
   * strains
   * kingoms
 
-
-
-A ``cazy_dictionary.json`` has been created and packaged within the ``cazy_webscraper`` 
-(the specific location is ``./scraper/file_io/cazy_dictionary.json``, where '.' is the directory 
-where the webscraper is installed). This allows users to use a variety of synonoms for the CAZy 
-classes, for example both "GH" and "Glycoside-Hydrolases" are accepted as synonoms for 
-"Glycoside Hydrolases (GHs)". Additionally, the retrieval of CAZy classes from the configuration 
-file is **not** case sensitive, therefore, both "gh" and "GH" are excepted. The excepted class 
-synonoms have beeen written out in a json file to enale easy editing of this file if additional 
-accepted synonoms are to be added, of it a new CAZy class is defined then this class only needs 
-to be added to the json file, without needing to modify the entire webscraper. 
-
-If you having issues with the scraper retrieving the list of CAZy classes that are written under 
-'classes' in the configuration file, please check the dictionary first to see the full list of 
-accepted synonoms. If you are comfortable modifying json files then feel free to add your own 
-synonoms to the dictionary.
-
-Each class must be listed on a separate line, indented by 4 spaces, and the class name encapsulated 
-with single or double quotation marks. For example:
+Each value in the YAML mappings for these arguments must be listed on a separate line, indented by 4 spaces, and the class name encapsulated with single or double quotation marks. For example:
 
 .. code-block:: yaml
 
     classes:
-        - "GH"
+        - "GT"
         - "pl"
-
-
-Specifying specific families to scrape
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Under the each of the class names listed in the configuration file, list the names of specific 
-**families** to be scraped from that class. The respective classes of the specificed families do 
-**not** need to be added to the 'classes' list.
-
-Write the true name of the family not only it's number, for example **GH1** is excepted by **1** is 
-not. Name families using the standard CAZy nomenclature, such as **"GT2"** and 
-**NOT "GlycosylTransferases_2"**. Additionally, use the standard CAZy notation for subfamilies 
-(**GH3_1**).
-
-.. warning::
-   If any subfamilies are listed within the configuration file, the retrieval of subfamilies 
-   **must** be enabled at the command line uisng ``--subfamilies``.
-
-Each family must be listed on a separate line and the name surrounded by double or single quotation 
-marks. For example:
-
-.. code-block:: yaml
-
     Glycoside Hydrolases (GHs):
         - "GH1"
         - "GH2"
 
 
-Configuration when scraping subfamilies
----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Synonyms for CAZy classes
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If any subfamilies are listed within the configuration file, the retrieval of subfamilies **must** 
-be enabled at the command line uisng ``--subfamilies``.
+A number of synonyms may be provided for CAZy classes, e.g. both "GH" and "Glycoside-Hydrolases" are accepted as synonyms for "Glycoside Hydrolases (GHs)" (the name recorded at CAZy). These alternatives are defined in the ``cazy_webscraper`` repository, in the file ``scraper/utilities/parse_configuration/cazy_dictionary.json``.
 
-If the parent family, e.g GH3, is listed in the configuration file and ``--subfamilies`` is enabled, 
-all proteins catalogued under GH3 and its subfamilies will be retrieved. This is to save time 
-having to write out all the subfamilies for a given CAZy family. The scraper will remove any 
-duplicate proteins automatically.
+-------------------------
+Scraping CAZy subfamilies
+-------------------------
 
+``cazy_webscraper`` can scrape CAZy subfamilies, using the standard CAZy notation for subfamilies 
+(e.g. ``GH3_1``).
 
-An example configuration file
------------------------------
+.. NOTE::
+   If any subfamilies are specified for download/scraping in the YAML file, the command line argument ``--subfamilies`` must be used.
 
-A blank configuration file is packaged within ``cazy_webscraper``, within the ``scraper`` directory, 
-called ``scraper_config.yaml``. This configuration file contains comments to assit filling in the 
-file correctly. A new configuration file with any given name can be created and used. However, 
-it **must** be a Yaml file and it **must** use the same headings/tags as used in the configuration 
-file ``scraper_config.yaml``.Please find more information on writing lists in Yaml files 
-[here](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html).
-
-Below is an example of how the configuration file may look.
-
-.. code-block:: yaml
-
-    classes:
-        - "AA"
-    Glycoside Hydrolases (GHs):
-        - "GH1"
-        - "GH3"
-    GlycosylTransferases (GTs):
-    Polysaccharide Lyases (PLs):
-        - "PL9"
-    Carbohydrate Esterases (CEs):
-    Auxiliary Activities (AAs):
-    Carbohydrate-Binding Modules (CBMs):
-
-
-..note::
-    Indentations consist of 4 spaces.
+If a parent CAZy family is listed in the configuration file and ``--subfamilies`` is enabled at the command-line, all proteins catalogued under the named family and its subfamilies will be retrieved.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,6 +1,6 @@
-===========================================
-Configuring the CAZy webscraper
-===========================================
+=========================
+Using ``cazy_webscraper``
+=========================
 
 ``cazy_webscraper`` can be configured to retrieve user specified data sets from CAZy. The configuration 
 applies to the retrieval of protein sequences from GenBank and protein structure files from PDB.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -2,15 +2,27 @@
 Using ``cazy_webscraper``
 =========================
 
-``cazy_webscraper`` can be used to retrieve user-specified data sets from the CAZy database. The ``cazy_webscraper`` application can be invoked _via_ the command line
+``cazy_webscraper`` can be used to retrieve user-specified data sets from the CAZy database. The ``cazy_webscraper`` application can be invoked *via* the command line
+
+-------------
+Example Usage
+-------------
+
+To download the single CAZy family GH169, use the command:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 -o GH169
+
+This will create a new directory ``GH169`` in the current working directory, and will download all CAZy entries in the GH169 family to a new SQLite3 database in that directory.
 
 .. NOTE::
-  ``cazy_webscraper`` options can be specified in a **YAML configuration file**, to enable transparency and reproducibility.
+  ``cazy_webscraper`` input options can also be specified in a **YAML configuration file**, to enable transparency and reproducibility.
 
 This page provides a brief summary of command-line options for ``cazy_webscraper`` that control the retrieval of data sets from the CAZy database, including:
 
 * Retrieve only specified CAZy classes and families or subfamilies
-* Retrieve only CAZymes from taxonomic kingdoms, genera, species, or strains
+* Retrieve only CAZymes from specified taxonomic kingdoms, genera, species, or strains
 * Recover only CAZymes with specified EC numbers
 * Local SQLite3 database path
 * Verbosity level and logging options
@@ -115,23 +127,71 @@ Command line options
 Basic Usage
 -----------
 
-The command-line options listed above can be used in any combination to customise the scraping of CAZy. The options that apply a 'filter' 
-to restrict which CAZymes are scraped from CAZy are applied in combination. For example, if the ``--families`` option and ``--ec`` option are called then 
-only CAZymes from the specified families **and** annotated with the listed EC numbers will be retrieved.
+The command-line options listed above can be used in combination to customise the scraping of CAZy. Some options (e.g. ``--families`` and ``--classes``) define the broad group of data that will be scraped, others (e.g. ``--species``) are used to filter and fine-tune the data that is scraped.
 
-Below are some example commands for invoking the ``cazy_webscraper`` to help demonstrate how to configure the webscraper at the command line.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Defining CAZy families and classes to scrape
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. Writing the output to the directory 'my_output' and enabling retrieval of subfamilies:  
-``python3 cazy_webscraper.py -o my_output -s``
+The 'definition' arguments (e.g. ``--classes`` and ``--families``) are applied singly, e.g.
 
-2. Retrieving all CAZymes derived from bacteria and annotated with the EC numbers EC1.2.3.4 or EC1.5.3.4
-``python3 cazy_webscraper.py --kingdoms bacteria --ec EC1.2.3.4,EC``
+.. code-block:: bash
 
-3. Writing the output to an existing directory but do not delete the content already present in the directory:  
-``python3 cazy_webscraper.py --output docs/my_output -f -n``
+  cazy_webscraper --families GH169 -o GH169
+  cazy_webscraper --classes AA -o AA
 
-4. Write out the data retrieved from CAZy to an existing database, and only retrieve data for CAZymes derived from Aspergiulls species from families GH13, GH15 and PL9, and all CE familes:  
-``python3 cazy_webscraper.py -d docs/my_cazy_database/cazy_scrape_2021-04-27--11-54-58.db --genera Aspergillus --families GH13,GH15,PL9 --classes CE``
+but more than one class or family can be specified, e.g.
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169,GH1,GH2,GH3 -o GH_families
+  cazy_webscraper --classes AA,CBM -o other_classes
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Filtering CAZy families and classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Options that apply a *filter* to restrict which CAZymes from a class or familiy are scraped from CAZy (e.g. ``--species`` and ``--ec``) may be applied in combination. For example:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 \
+      --ec 1.1.1.1 --species "Escherichia coli" \
+      -o GH169_ec1.1.1.1_speciesEscherichia_coli
+
+will download only the CAZymes in the GH169 family that have EC number 1.1.1.1 *and* are from the species *Escherichia coli*. The command:
+
+.. code-block:: bash
+
+  cazy_webscraper --families PL14 \
+      --ec 1.2.3.4 --kingdoms bacteria \
+      -o PL14_ec1.2.3.4_kingdomBacteria
+
+will download only CAZymes in the PL14 familiy that have EC number 1.2.3.4 *and* are from the kingdom *Bacteria*.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Specifying output data location
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To specify the location of the output database and log files, the ``--output``/``-o`` option can be used:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 -o GH169_output
+
+will write output to the directory ``GH169_output``, and create a new CAZy database in that directory.
+
+If you already have an existing CAZy output directory with a database, then specifying this database with the ``-d``/``--database`` option will cause the scraper to use the existing database rather than creating a new one:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 -d GH169_output/cazy.db
+
+To write output to an existing directory without deleting the content already present, use the ``--force``/``-f`` and ``--nodelete``/``-n`` options:
+
+.. code-block:: bash
+
+  cazy_webscraper --families GH169 -d GH169_output -f -n
 
 
 Configuration via a YAML file


### PR DESCRIPTION
Some major changes to installation instructions - most notably removing over-detailed descriptions of how to navigate through a terminal, start a terminal on multiple operating systems, and so on. I've removed a fair amount of verbosity from the text in general.

Also, I think we need to be clear what is "usage" (i.e. employing the program to achieve a goal) and what is "configuration" (changing a setting, but not necessarily using the program). The YAML file is configuration because it can be written to set values, without running the program. Issuing a command-line instruction runs the program and is "usage." I've renamed "configuration" to usage up to the point I've reached, but the changes are not yet complete.