### PR TITLE
change relationship to one-to-many

### DIFF
--- a/scraper/sql/sql_orm.py
+++ b/scraper/sql/sql_orm.py
@@ -4,10 +4,10 @@
 # (c) University of Strathclyde 2020-2021
 # Author:
 # Emma E. M. Hobbs
-
+#
 # Contact
 # eemh1@st-andrews.ac.uk
-
+#
 # Emma E. M. Hobbs,
 # Biomolecular Sciences Building,
 # University of St Andrews,
@@ -16,7 +16,7 @@
 # KY16 9ST
 # Scotland,
 # UK
-
+#
 # The MIT License
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,10 +25,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -150,42 +150,42 @@ SQLITE_REGEX_FUNCTIONS = {
 # define association/relationship tables
 
 
-# linker table between cazymes and CAZy family and subfamilies
+# linker table between cazymes and CAZy (sub)families
 cazymes_families = Table(
-    "cazymes_families",
+    "CAZymes_Families",
     Base.metadata,
-    Column("cazyme_id", Integer, ForeignKey("cazymes.cazyme_id")),
-    Column("family_id", Integer, ForeignKey("families.family_id")),
+    Column("cazyme_id", Integer, ForeignKey("CAZymes.cazyme_id")),
+    Column("family_id", Integer, ForeignKey("Families.family_id")),
     PrimaryKeyConstraint("cazyme_id", "family_id"),
 )
 
 
 # linker table between cazymes and ec numbers
 cazymes_ecs = Table(
-    "cazymes_ecs",
+    "CAZymes_ECs",
     Base.metadata,
-    Column("cazyme_id", Integer, ForeignKey("cazymes.cazyme_id")),
-    Column("ec_id", Integer, ForeignKey("ecs.ec_id")),
+    Column("cazyme_id", Integer, ForeignKey("CAZymes.cazyme_id")),
+    Column("ec_id", Integer, ForeignKey("ECs.ec_id")),
     PrimaryKeyConstraint("cazyme_id", "ec_id"),
 )
 
 
 # linker table between cazymes and UniProt accessions of CAZymes
 cazymes_uniprots = Table(
-    "cazymes_uniprots",
+    "CAZymes_UniProts",
     Base.metadata,
-    Column("cazyme_id", Integer, ForeignKey("cazymes.cazyme_id")),
-    Column("uniprot_id", Integer, ForeignKey("uniprots.uniprot_id")),
+    Column("cazyme_id", Integer, ForeignKey("CAZymes.cazyme_id")),
+    Column("uniprot_id", Integer, ForeignKey("UniProts.uniprot_id")),
     PrimaryKeyConstraint("cazyme_id", "uniprot_id"),
 )
 
 
 # linker table between CAZymes and PDB structures
 cazymes_pdbs = Table(
-    "cazymes_pdbs",
+    "CAZymes_PDBs",
     Base.metadata,
-    Column("cazyme_id", Integer, ForeignKey("cazymes.cazyme_id")),
-    Column("pdb_id", Integer, ForeignKey("pdbs.pdb_id")),
+    Column("cazyme_id", Integer, ForeignKey("CAZymes.cazyme_id")),
+    Column("pdb_id", Integer, ForeignKey("PDBs.pdb_id")),
     PrimaryKeyConstraint("cazyme_id", "pdb_id"),
 )
 
@@ -194,33 +194,35 @@ cazymes_pdbs = Table(
 
 
 class Cazyme(Base):
-    """Describes a CAZyme, which is a protein single entry in CAZy.
+    """Describes a CAZyme, which is a single entry in CAZy.
 
-    Every CAZyme will have a name, a source organism, at least one CAZy family, and at least
-    a primary GenBank accession. A CAZyme may also have non-primary GenBank accessions, EC
+    Every CAZyme has a name, a source organism, at least one CAZy family, and
+    a primary GenBank accession.
+    
+    A CAZyme may also have non-primary GenBank accessions, EC
     number annotations, UniProt accessions and PDB accessions.
     """
-    __tablename__ = "cazymes"
+    __tablename__ = "CAZymes"
 
     cazyme_id = Column(Integer, primary_key=True)
     cazyme_name = Column(String)
-    taxonomy_id = Column(Integer, ForeignKey("taxs.taxonomy_id"))
+    taxonomy_id = Column(Integer, ForeignKey("Taxs.taxonomy_id"))
 
+    # one-to-many relationships
+    genbanks = relationship("Genbank")
+    
+    # many-to-one relationships
     taxonomy = relationship("Taxonomy", back_populates="cazymes")
-
+    
+    # many-to-many relationships
     families = relationship(
         "CazyFamily",
         secondary=cazymes_families,
         back_populates="cazymes",
         lazy="dynamic",
     )
-    cazymes_genbanks = relationship(
-        "Cazymes_Genbanks",
-        back_populates="cazymes",
-        lazy="dynamic",
-    )
 
-    # Not all CAZymes will have EC numbers, UniProt accessions or PDB accessions
+    # Not all CAZymes will have EC numbers, UniProt accessions and/or PDB accessions
     ecs = relationship(
         "EC",
         secondary=cazymes_ecs,
@@ -247,9 +249,47 @@ class Cazyme(Base):
         return f"<Class Cazyme: name={self.cazyme_name}, id={self.cazyme_id}>"
 
 
+class Genbank(Base):
+    """Describe a GenBank accession number of protein sequences.
+
+    The associated GenBank protein record is the source record from which CAZy retrieves the
+    protein sequence for the CAZyme.
+    
+    The primary GenBank accession is the only hyperlinked GenBank accession for the protein, 
+    is believed to be used by CAZy to indicate the source GenBank protein record for the 
+    record in CAZy. Defines these GenBank accessions as the 'best model'.
+    
+    It can not be guareenteed that a GenBank accession will only be recorded as a primary 
+    OR a non-primary accession. It may be possible that a GenBank accession is the primary
+    accession for one CAZyme and a non-primary accession for another. This is believed to be
+    possible becuase CAZy does not appear to ID unique proteins by the GenBank accession because
+    duplicate  CAZyme entries can be found within CAZy.
+    """
+    __tablename__ = "GenBanks"
+    __table_args__ = (
+        UniqueConstraint("cazyme_id", "genbank_id", "genbank_accession", "primary"),
+    )
+
+    cazyme_id = Column(Integer, ForeignKey("CAZymes.cazyme_id"))
+    genbank_id = Column(Integer, primary_key=True)
+    genbank_accession = Column(String, index=True)
+    primary = Column(Boolean, index=True)
+    sequence = Column(String)
+    seq_update_date = Column(String)  # 'YYYY/MM/DD'
+    
+    # define relationship
+    cazyme = relationship("Cazyme", back_populates="genbanks")
+
+    def __str__(self):
+        return f"-Genbank accession={self.genbank_accession} primary={self.primary}-"
+
+    def __repr__(self):
+        return f"<Class GenBank acc={self.genbank_accession} primary={self.primary}>"
+
+    
 class Taxonomy(Base):
     """Describes the source organism of CAZymes."""
-    __tablename__ = "taxs"
+    __tablename__ = "Taxs"
     __table_args__ = (
         UniqueConstraint("genus", "species"),
         Index("organism_index", "genus", "species", "kingdom_id")
@@ -258,7 +298,7 @@ class Taxonomy(Base):
     taxonomy_id = Column(Integer, primary_key=True)
     genus = Column(String)
     species = Column(String)
-    kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
+    kingdom_id = Column(Integer, ForeignKey("Kingdoms.kingdom_id"))
 
     tax_kingdom = relationship("Kingdom", back_populates="taxonomy")
 
@@ -275,7 +315,7 @@ class Taxonomy(Base):
 
 class Kingdom(Base):
     """Describes a taxonomy Kingdom."""
-    __tablename__ = "kingdoms"
+    __tablename__ = "Kingdoms"
     __table_args__ = (
         UniqueConstraint("kingdom"),
     )
@@ -300,7 +340,7 @@ class CazyFamily(Base):
     will be listed together, and given a single family_id. If another protein is catalogued
     under only the parent CAZy family, another entry with for the CAZy family will be made with
     a null value for the subfamily and a different family_id. """
-    __tablename__ = "families"
+    __tablename__ = "Families"
 
     family_id = Column(Integer, primary_key=True)
     family = Column(ReString, nullable=False)
@@ -337,76 +377,12 @@ class CazyFamily(Base):
         )
 
 
-class Genbank(Base):
-    """Describe a GenBank accession number of protein sequences.
-
-    The associated GenBank protein record is the source record from which CAZy retrieves the
-    protein sequence for the CAZyme.
-    """
-    __tablename__ = "genbanks"
-    __table_args__ = (
-        UniqueConstraint("genbank_accession"),
-    )
-
-    genbank_id = Column(Integer, primary_key=True)
-    genbank_accession = Column(String, index=True)
-    sequence = Column(String)
-    seq_update_date = Column(String)  # 'YYYY/MM/DD'
-
-    cazymes_genbanks = relationship(
-        "Cazymes_Genbanks",
-        back_populates="genbanks",
-        lazy="dynamic",
-    )
-
-    def __str__(self):
-        return f"-Genbank accession={self.genbank_accession}-"
-
-    def __repr__(self):
-        return f"<Class GenBank acc={self.genbank_accession}>"
-
-
-class Cazymes_Genbanks(Base):
-    """Represent assoication between a CAZyme and its primary and non-primary GenBank accessions.
-
-    The primary GenBank accession is the only hyperlinked
-    GenBank accession for the protein, and believed to be used by CAZy to indicate the source
-    GenBank protein record for the record in CAZy. It can not be guareenteed that a GenBank
-    accession will only be recorded as a primary OR a non-primary accession. It may be possible
-    that a GenBank accession is the primary accession for one CAZyme and a non-primary accession
-    for another. This is believed to be possible becuase CAZy does not appear to ID unique proteins
-    by the GenBank accession because duplicate entries for CAZyme can be found within CAZy.
-    """
-    __tablename__ = "cazymes_genbanks"
-    __table_args__ = (
-        UniqueConstraint("cazyme_id", "genbank_id", "primary"),
-    )
-
-    link_id = Column(Integer, primary_key=True)  # unique ID of the CAZyme-GenBank relationship
-    cazyme_id = Column(Integer, ForeignKey("cazymes.cazyme_id"))
-    genbank_id = Column(Integer, ForeignKey("genbanks.genbank_id"))
-
-    primary = Column(Boolean, index=True)
-
-    cazymes = relationship("Cazyme", back_populates="cazymes_genbanks")
-    genbanks = relationship("Genbank", back_populates="cazymes_genbanks")
-
-    def __str__(self):
-        return f"cazyme_id={self.cazyme_id}--genbank_id={self.genbank_id}--primary={self.primary}-"
-
-    def __repr__(self):
-        return(
-            f"<Class Cazymes_GenBanks cazyme_id={self.cazyme_id}-"
-            f"-genbank_id={self.genbank_id}-primary={self.primary}>"
-        )
-
-
 # Not all CAZymes will have EC numbers, UniProt accessions or PDB accessions
 
 
 class EC(Base):
     """Describe EC numbers."""
-    __tablename__ = "ecs"
+    __tablename__ = "ECs"
     __table_args__ = (
         UniqueConstraint("ec_number"),
     )
@@ -429,7 +405,7 @@ class Uniprot(Base):
     The primary UniProt accession is the first UniProt accession that is lsited in UniProt for
     the CAZyme.
     """
-    __tablename__ = "uniprots"
+    __tablename__ = "UniProts"
     __table_args__ = (
         UniqueConstraint("uniprot_accession", "primary"),
     )
@@ -464,7 +440,7 @@ class Uniprot(Base):
 
 class Pdb(Base):
     """Describe a PDB accession number of protein structure."""
-    __tablename__ = "pdbs"
+    __tablename__ = "PDBs"
     __table_args__ = (
         UniqueConstraint("pdb_accession"),
     )
@@ -474,7 +450,12 @@ class Pdb(Base):
 
     Index('pdb_idx', pdb_accession)
 
-    cazymes = relationship("Cazyme", secondary=cazymes_pdbs, back_populates="pdbs", lazy="dynamic")
+    cazymes = relationship(
+        "Cazyme",
+        secondary=cazymes_pdbs,
+        back_populates="pdbs",
+        lazy="dynamic",
+    )
 
     def __str__(self):
         return f"-PDB accession={self.pdb_accession}, id={self.pdb_id}-"
@@ -485,7 +466,7 @@ class Pdb(Base):
 
 class Log(Base):
     """Record what data was added to the database and when."""
-    __tablename__ = "logs"
+    __tablename__ = "Logs"
 
     log_id = Column(Integer, primary_key=True)
     date = Column(String)  # date CAZy scrape was initiated


### PR DESCRIPTION
- Correct the previous CAZyme-to-GenBank many-to-many relationship to one-to-many.
- All table names now start with capital letters
- Add CAZy family once per passing of CAZy family, instead of attempting to add the CAZy family for each member of the family and having to pass _many_ integrity errors
- Add all CAZymes from a single webpage at once, and handle all integrity errors at once, instead of per record in CAZy