### PR TITLE
Fix tax invalid ids

### DIFF
--- a/cazy_webscraper/__init__.py
+++ b/cazy_webscraper/__init__.py
@@ -54,7 +54,7 @@ from saintBioutils.utilities.file_io import make_output_directory
 from cazy_webscraper.sql import sql_orm
 
 
-__version__ = "2.2.5"
+__version__ = "2.2.6"
 
 
 VERSION_INFO = f"cazy_webscraper version: {__version__}"

--- a/cazy_webscraper/ncbi/taxonomy/multiple_taxa.py
+++ b/cazy_webscraper/ncbi/taxonomy/multiple_taxa.py
@@ -132,7 +132,12 @@ def replace_multiple_tax(cazy_data, genbank_accessions, replaced_taxa_logger, ar
 
         else:
             # first time replace_multiple_tax was called
-            cazy_data, success = replace_multiple_tax_with_invalid_ids(cazy_data, args)
+            cazy_data, success = replace_multiple_tax_with_invalid_ids(
+                cazy_data,
+                gbk_accessions,
+                replaced_taxa_logger,
+                args,
+            )
 
     if success is False:
         logger.error(

--- a/cazy_webscraper/ncbi/taxonomy/multiple_taxa.py
+++ b/cazy_webscraper/ncbi/taxonomy/multiple_taxa.py
@@ -134,7 +134,7 @@ def replace_multiple_tax(cazy_data, genbank_accessions, replaced_taxa_logger, ar
             # first time replace_multiple_tax was called
             cazy_data, success = replace_multiple_tax_with_invalid_ids(
                 cazy_data,
-                gbk_accessions,
+                genbank_accessions,
                 replaced_taxa_logger,
                 args,
             )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ with Path("README.md").open("r") as long_description_handle:
 
 setuptools.setup(
     name="cazy_webscraper",
-    version="2.2.5",
+    version="2.2.6",
     # Metadata
     author="Emma E. M. Hobbs",
     author_email="eemh1@st-andrews.ac.uk",


### PR DESCRIPTION
Fix `cazy_webscraper` crashing from missing arguments to function calls when retrieving the latest taxonomic classifications for proteins when a batch on protein IDs contains an invalid ID:

```
Traceback (most recent call last):
  File "...bin/cazy_webscraper", line 33, in <module>
    sys.exit(load_entry_point('cazy-webscraper', 'console_scripts', 'cazy_webscraper')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../cazy_webscraper/cazy_scraper.py", line 246, in main
    get_cazy_data(
  File "...//cazy_webscraper/cazy_scraper.py", line 355, in get_cazy_data cazy_data, successful_replacement = replace_multiple_tax(
                                        ^^^^^^^^^^^^^^^^^^^^^
  File ".../cazy_webscraper/ncbi/taxonomy/multiple_taxa.py", line 135, in replace_multiple_tax
    cazy_data, success = replace_multiple_tax_with_invalid_ids(cazy_data, args)
```