### PR TITLE
Issue 109

### DIFF
--- a/cazy_webscraper/__init__.py
+++ b/cazy_webscraper/__init__.py
@@ -54,7 +54,7 @@ from saintBioutils.utilities.file_io import make_output_directory
 from cazy_webscraper.sql import sql_orm
 
 
-__version__ = "2.2.6"
+__version__ = "2.2.7"
 
 
 VERSION_INFO = f"cazy_webscraper version: {__version__}"

--- a/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
+++ b/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
@@ -253,7 +253,9 @@ def get_cache_seqs(start_time, args):
     for key in seq_dict:
         seq_records.append(SeqRecord(id=key, seq=Seq(seq_dict[key])))
 
-    return seq_dict
+    logger.warning(f"Retrieved {len(seq_records)} from cache")
+
+    return seq_dict, seq_records
 
 
 def get_records_to_retrieve(

--- a/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
+++ b/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
@@ -154,7 +154,7 @@ def main(argv: Optional[List[str]] = None, logger: Optional[logging.Logger] = No
         )
 
     else:  # retrieve data from NCBI for seqs in the local db
-        seq_dict, seq_records = get_seqs_from_ncbi(
+        seq_dict = get_seqs_from_ncbi(
             seq_records,
             accs_seqs_to_retrieve,
             seq_dict,
@@ -407,7 +407,7 @@ def get_seqs_from_ncbi(
             for acc in batch:
                 individual_batches.append([acc])
 
-        seq_records, accs_still_to_fetch = parse_invalid_id_batches(
+        seq_records = parse_invalid_id_batches(
             seq_records,
             batches_with_invalid_ids,
             cache_path,
@@ -642,7 +642,8 @@ def parse_invalid_id_batches(
     """Separate accessions in batches containing invalid IDs. Retrieve seqs for valid IDs.
 
     :param seq_records: list of Bio.SeqRecords
-    :param batches_with_invalid_ids: list of batches containing invalid IDs
+    :param batches_with_invalid_ids: list of accessions from batches containing invalid IDs
+        NOT NESTED LISTS
     :param cache_path: path to cache downloaded seqs
     :param invalid_ids_cache: path to cache invalid IDs
     :param args: CLI args parser
@@ -651,11 +652,8 @@ def parse_invalid_id_batches(
     """
     logger = logging.getLogger(__name__)
 
-    # separaet accessions into individual batches to identify invalid IDs
-    batches = []
-    for batch in batches_with_invalid_ids:
-        for acc in batch:
-            batches.append([acc])
+    # turn into list of lists of len 1
+    batches = [acc for acc in batches_with_invalid_ids]
 
     logger.warning(
         "Separted accessions in batches containing invalid IDs.\n"

--- a/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
+++ b/cazy_webscraper/expand/genbank/sequences/get_genbank_sequences.py
@@ -251,7 +251,7 @@ def get_cache_seqs(start_time, args):
             closing_message("Get GenBank seqs", start_time, args, early_term=True)
 
     for key in seq_dict:
-        seq_records.append(SeqRecord(id=key, seq=Seq(seq_dict[key]))
+        seq_records.append(SeqRecord(id=key, seq=Seq(seq_dict[key])))
 
     return seq_dict
 

--- a/cazy_webscraper/ncbi/sequences/__init__.py
+++ b/cazy_webscraper/ncbi/sequences/__init__.py
@@ -198,77 +198,77 @@ def fetch_ncbi_seqs(seq_records, epost_webenv, epost_query_key, acc_to_retrieve,
                 seq_records.append(record)
                 successful_accessions.add(retrieved_accession)
 
-                except RuntimeError as err:
-                    if repr(err).startswith("RuntimeError('Some IDs have invalid value and were omitted.") or repr(err).startswith("RuntimeError('Empty ID list; Nothing to store')"):
-                        
-                        if len(batch) == 1:
-                            logger.warning(
-                                f"Accession '{batch[0]}' not listed in NCBI. Querying NCBI returns the error:\n"
-                                f"{repr(err)}\n"
-                                f"Not retrieving seq for '{batch[0]}'"
-                            )
-                            success = "Invalid ID"
-                        
-                        else:
-                            logger.warning(
-                                "Batch contains an accession no longer listed in NCBI\n"
-                                f"Querying NCBI returns the error:\n{err}\n"
-                                "Will identify invalid ID(s) later"
-                            )
-                            success = "Contains invalid ID"
+    except RuntimeError as err:
+        if repr(err).startswith("RuntimeError('Some IDs have invalid value and were omitted.") or repr(err).startswith("RuntimeError('Empty ID list; Nothing to store')"):
+            
+            if len(batch) == 1:
+                logger.warning(
+                    f"Accession '{batch[0]}' not listed in NCBI. Querying NCBI returns the error:\n"
+                    f"{repr(err)}\n"
+                    f"Not retrieving seq for '{batch[0]}'"
+                )
+                success = "Invalid ID"
+            
+            else:
+                logger.warning(
+                    "Batch contains an accession no longer listed in NCBI\n"
+                    f"Querying NCBI returns the error:\n{err}\n"
+                    "Will identify invalid ID(s) later"
+                )
+                success = "Contains invalid ID"
 
-                    else:  # unrecognised Runtime error
-                        if len(batch) == 1:
-                            logger.warning(
-                                f"Runtime error occured when fetching record from NCBI for accession '{batch[0]}'\n"
-                                f"Error returned:\n{err}\n"
-                                "Interrupting error as recognition of an invalid ID. Therefore,\n"
-                                f"not adding seq for '{batch[0]} to the local CAZyme db'"
-                            )
-                            success = "Invalid ID"
+        else:  # unrecognised Runtime error
+            if len(batch) == 1:
+                logger.warning(
+                    f"Runtime error occured when fetching record from NCBI for accession '{batch[0]}'\n"
+                    f"Error returned:\n{err}\n"
+                    "Interrupting error as recognition of an invalid ID. Therefore,\n"
+                    f"not adding seq for '{batch[0]} to the local CAZyme db'"
+                )
+                success = "Invalid ID"
 
-                        else:
-                            logger.warning(
-                                f"Runtime error occured when fetching records from NCBI\n"
-                                f"Error returned:\n{err}\n"
-                                "Interrupting error as batch containing invalid ID.\n"
-                                "Will identify invalid ID(s) later"
-                            )
-                            success = "Contains invalid ID"
+            else:
+                logger.warning(
+                    f"Runtime error occured when fetching records from NCBI\n"
+                    f"Error returned:\n{err}\n"
+                    "Interrupting error as batch containing invalid ID.\n"
+                    "Will identify invalid ID(s) later"
+                )
+                success = "Contains invalid ID"
 
-                except IncompleteRead as err:
-                    logger.warning(
-                        "IncompleteRead error raised when fetching record from NCBI:\n"
-                        f"{err}\n"
-                        "Will reattempt NCBI query later"
-                    )
-                    success = "Failed connection"
+    except IncompleteRead as err:
+        logger.warning(
+            "IncompleteRead error raised when fetching record from NCBI:\n"
+            f"{err}\n"
+            "Will reattempt NCBI query later"
+        )
+        success = "Failed connection"
 
-                except NotXMLError as err:
-                    logger.warning(
-                        "NotXMLError raised when fetching record(s) from NCBI:\n"
-                        f"{err}\n"
-                        "Will reattempt NCBI query later"
-                    )
-                    success = "Failed connection"
+    except NotXMLError as err:
+        logger.warning(
+            "NotXMLError raised when fetching record(s) from NCBI:\n"
+            f"{err}\n"
+            "Will reattempt NCBI query later"
+        )
+        success = "Failed connection"
 
-                except (TypeError, AttributeError) as err:  # if no record is returned from call to Entrez
-                    logger.warning(
-                        f"Error occurenced when fetching records from NCBI\n"
-                        "Error retrieved:\n"
-                        f"{repr(err)}\n"
-                        "Will retry batch later"
-                    )
-                    success = "Failed connection"
+    except (TypeError, AttributeError) as err:  # if no record is returned from call to Entrez
+        logger.warning(
+            f"Error occurenced when fetching records from NCBI\n"
+            "Error retrieved:\n"
+            f"{repr(err)}\n"
+            "Will retry batch later"
+        )
+        success = "Failed connection"
 
-                except Exception as err:  # if no record is returned from call to Entrez
-                    logger.warning(
-                        f"Error occurenced when fetching sequences from NCBI\n"
-                        "Error retrieved:\n"
-                        f"{repr(err)}\n"
-                        "Will retry batch later"
-                    )
-                    success = "Failed connection"
+    except Exception as err:  # if no record is returned from call to Entrez
+        logger.warning(
+            f"Error occurenced when fetching sequences from NCBI\n"
+            "Error retrieved:\n"
+            f"{repr(err)}\n"
+            "Will retry batch later"
+        )
+        success = "Failed connection"
 
     return seq_records, success, list(successful_accessions)
 

--- a/cazy_webscraper/ncbi/sequences/__init__.py
+++ b/cazy_webscraper/ncbi/sequences/__init__.py
@@ -287,35 +287,31 @@ def get_protein_accession(record):
     retrieved_accession = None
 
     # check if multiple items returned in ID
+    # try re search for accession in string
     try:
-        retrieved_accession = [_.strip() for _ in record.id.split("|") if _.strip() in acc_to_retrieve][0]
+        retrieved_accession = re.match(r"\D{3}\d+\.\d+", record.id).group()
 
-    except IndexError:
-        # try re search for accession in string
+    except AttributeError:
         try:
-            retrieved_accession = re.match(r"\D{3}\d+\.\d+", record.id).group()
+            retrieved_accession = re.match(r"\D{2}_\d+\.\d+", record.id).group()
 
         except AttributeError:
-            try:
-                retrieved_accession = re.match(r"\D{2}_\d+\.\d+", record.id).group()
+            for acc in acc_to_retrieve:
+                if record.id.find(acc) != -1:
+                    retrieved_accession = acc
 
-            except AttributeError:
-                # Accession may be a UniProt entry name or ID
-                # e.g. 'prf||2109195A'or 'sp|B2FSW8.1|EALGL_STRMK'
-                if len(record.id.split("|")) == 3:
+    if retrieved_accession is None:
+        # Accession may be a UniProt entry name or ID
+        # e.g. 'prf||2109195A'or 'sp|B2FSW8.1|EALGL_STRMK'
+        if len(record.id.split("|")) == 3:
 
-                    if record.id.startswith("sp"):
-                        if len(record.id.split("|")[1]) == 0:
-                            retrieved_accession = record.id.split("|")[2]
-                        else:
-                            retrieved_accession = record.id.split("|")[1]
-                    
-                    elif len(record.id.split("|")[1]) == 0:
-                        retrieved_accession = record.id.split("|")[2]
-
-                    else:
-                        for acc in acc_to_retrieve:
-                            if record.id.find(acc) != -1:
-                                retrieved_accession = acc
+            if record.id.startswith("sp"):
+                if len(record.id.split("|")[1]) == 0:
+                    retrieved_accession = record.id.split("|")[2]
+                else:
+                    retrieved_accession = record.id.split("|")[1]
+            
+            elif len(record.id.split("|")[1]) == 0:
+                retrieved_accession = record.id.split("|")[2]
     
     return retrieved_accession

--- a/cazy_webscraper/ncbi/sequences/__init__.py
+++ b/cazy_webscraper/ncbi/sequences/__init__.py
@@ -187,6 +187,9 @@ def fetch_ncbi_seqs(seq_records, epost_webenv, epost_query_key, acc_to_retrieve,
             for record in SeqIO.parse(seq_handle, "fasta"):
                 retrieved_accession = get_protein_accession(record)
 
+                if retrieved_accession not in acc_to_retrieve:
+                    retrieved_accession = None
+
                 if retrieved_accession is None:
                     logger.error(
                         "Could not retrieve a NCBI protein version accession matching\n"
@@ -273,11 +276,10 @@ def fetch_ncbi_seqs(seq_records, epost_webenv, epost_query_key, acc_to_retrieve,
     return seq_records, success, list(successful_accessions)
 
 
-def get_protein_accession(record, acc_to_retrieve):
+def get_protein_accession(record):
     """Extract NCBI Protein accession from SeqRecord.
 
     :param record: BioPython SeqRecord obj
-    :param acc_to_retrieve: list of NCBI protein version accessions to retrieved from NCBI
 
     Return str (accession) or None:
     """
@@ -315,8 +317,5 @@ def get_protein_accession(record, acc_to_retrieve):
                         for acc in acc_to_retrieve:
                             if record.id.find(acc) != -1:
                                 retrieved_accession = acc
-    
-    if retrieved_accession not in acc_to_retrieve:
-        retrieved_accession = None
     
     return retrieved_accession

--- a/cazy_webscraper/ncbi/sequences/__init__.py
+++ b/cazy_webscraper/ncbi/sequences/__init__.py
@@ -185,7 +185,7 @@ def fetch_ncbi_seqs(seq_records, epost_webenv, epost_query_key, acc_to_retrieve,
             retmode="text",
         ) as seq_handle:
             for record in SeqIO.parse(seq_handle, "fasta"):
-                retrieved_accession = get_protein_accession(record)
+                retrieved_accession = get_protein_accession(record, acc_to_retrieve=acc_to_retrieve)
 
                 if retrieved_accession not in acc_to_retrieve:
                     retrieved_accession = None
@@ -276,10 +276,11 @@ def fetch_ncbi_seqs(seq_records, epost_webenv, epost_query_key, acc_to_retrieve,
     return seq_records, success, list(successful_accessions)
 
 
-def get_protein_accession(record):
+def get_protein_accession(record, acc_to_retrieve=None):
     """Extract NCBI Protein accession from SeqRecord.
 
     :param record: BioPython SeqRecord obj
+    :param acc_to_retrieve: list of acc to retrieve seqs for
 
     Return str (accession) or None:
     """
@@ -296,9 +297,10 @@ def get_protein_accession(record):
             retrieved_accession = re.match(r"\D{2}_\d+\.\d+", record.id).group()
 
         except AttributeError:
-            for acc in acc_to_retrieve:
-                if record.id.find(acc) != -1:
-                    retrieved_accession = acc
+            if acc_to_retrieve is not None:
+                for acc in acc_to_retrieve:
+                    if record.id.find(acc) != -1:
+                        retrieved_accession = acc
 
     if retrieved_accession is None:
         # Accession may be a UniProt entry name or ID

--- a/cazy_webscraper/ncbi/sequences/__init__.py
+++ b/cazy_webscraper/ncbi/sequences/__init__.py
@@ -315,5 +315,25 @@ def get_protein_accession(record, acc_to_retrieve=None):
             
             elif len(record.id.split("|")[1]) == 0:
                 retrieved_accession = record.id.split("|")[2]
+
+        if retrieved_accession is None:  # Accept Uniprot-style accessions which ar sometimes used
+            try:
+                retrieved_accession = re.match(r"\D\d+\.\d+", record.id).group()
+            except AttributeError:
+                try:
+                    retrieved_accession = re.match(r"\D\d{2}\D+\d+\.\d+", record.id).group()
+                except AttributeError:
+                    try:
+                        retrieved_accession = re.match(r"\D\d+\.\d+", record.id).group()
+                    except AttributeError:
+                        try:
+                            if record.id == re.match(r"\D\d{2}\D+\d+", record.id).group():
+                                retrieved_accession = re.match(r"\D\d{2}\D+\d+", record.id).group()
+                        except AttributeError:
+                            try:
+                                if record.id == re.match(r"\D\d+", record.id).group():
+                                    retrieved_accession = re.match(r"\D\d+", record.id).group()
+                            except AttributeError:
+                                retrieved_accession = None
     
     return retrieved_accession

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ with Path("README.md").open("r") as long_description_handle:
 
 setuptools.setup(
     name="cazy_webscraper",
-    version="2.2.6",
+    version="2.2.7",
     # Metadata
     author="Emma E. M. Hobbs",
     author_email="eemh1@st-andrews.ac.uk",


### PR DESCRIPTION
Fixing bugs when downloading seqs from NCBI:

* Issue #109 
* Adding missing args to func calls
* Accept UniProt-style accessions and non-standard NCBI accession formats that are used by NCBI
* Combine cached seqs with recently downloaded so don't need to manually combine multiple caches if the download is interrupted multiple times
* Remove unused args from func returns