### PR TITLE
add not on cw_get_uniprot before cw_get_pdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ To extract GenBank and/or UniProt protein sequences from a local CAZyme database
 
 To protein structure files from PDB use the `cw_get_pdb_structures` command.
 
+**Note:** PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using `cazy_webscraper`. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the `cw_get_uniprot_data` command must be used to retrieve PDB accessions from the UniProt database **prior** to using the `cw_get_pdb_structures` command.
+
 #### Interrogate the database
 
 To interrogate the database, use the `cw_query_database` command.

--- a/docs/pdb.rst
+++ b/docs/pdb.rst
@@ -12,7 +12,7 @@ For specific information of the ``Bio.PDB`` module please see the
         opretional outside peak times.
 
 .. note::
-    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** tousing the ``cw_get_pdb_structures`` command.
+    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** to using the ``cw_get_pdb_structures`` command.
 
 -----------
 Quick Start

--- a/docs/pdb.rst
+++ b/docs/pdb.rst
@@ -12,7 +12,7 @@ For specific information of the ``Bio.PDB`` module please see the
         opretional outside peak times.
 
 .. note::
-    PDB structure files are retrieved for the PDB accessions *in* a local CAZyme database created using ``cazy_webscraper``.
+    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** tousing the ``cw_get_pdb_structures`` command.
 
 -----------
 Quick Start

--- a/docs/pdbtutorial.rst
+++ b/docs/pdbtutorial.rst
@@ -19,6 +19,9 @@ the retrieval of protein structured from PDB. These tutorials are designed for t
 .. NOTE::
   If you installed ``cazy_webscraper`` using ``bioconda`` or ``pip`` to invoke ``cazy_webscraper`` to retrieve PDB data call it using ``cw_get_pdb_structures`` - this is the method used in this tutorial.  
   If you installed ``cazy_webscraper`` from source then you will need to invoke ``cazy_webscraper`` from the root of the repo using the command ``python3 cazy_webscraper/expand/pdb/get_pdb_structures.py``.
+  
+.. note::
+    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** tousing the ``cw_get_pdb_structures`` command.
 
 From this point on, we will be discussed the ``cw_get_pdb_structures``, which is the entry point for 
 retrieving data from PDB. We also presume you are comfortable configuring ``cazy_webscraper`` for the 

--- a/docs/pdbtutorial.rst
+++ b/docs/pdbtutorial.rst
@@ -21,7 +21,7 @@ the retrieval of protein structured from PDB. These tutorials are designed for t
   If you installed ``cazy_webscraper`` from source then you will need to invoke ``cazy_webscraper`` from the root of the repo using the command ``python3 cazy_webscraper/expand/pdb/get_pdb_structures.py``.
   
 .. note::
-    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** tousing the ``cw_get_pdb_structures`` command.
+    PDB structure files are retrieved for the PDB accessions that are *in* a local CAZyme database created using ``cazy_webscraper``. A freshly built CAZyme database only contains NCBI protein accessions, taxonomic kingdoms, source organisms, and CAZy family annotations. Therefore, the ``cw_get_uniprot_data`` command must be used to retrieve PDB accessions from the UniProt database **prior** to using the ``cw_get_pdb_structures`` command.
 
 From this point on, we will be discussed the ``cw_get_pdb_structures``, which is the entry point for 
 retrieving data from PDB. We also presume you are comfortable configuring ``cazy_webscraper`` for the 


### PR DESCRIPTION
Add additional note to documentation to highlight the need to run `cw_get_uniprot_data` before running `cw_get_pdb_structures` - as referenced in issues #111