### PR TITLE
Add batch ncbi tax

### DIFF
--- a/cazy_webscraper/__init__.py
+++ b/cazy_webscraper/__init__.py
@@ -54,7 +54,7 @@ from saintBioutils.utilities.file_io import make_output_directory
 from cazy_webscraper.sql import sql_orm
 
 
-__version__ = "2.2.7"
+__version__ = "2.2.8"
 
 
 VERSION_INFO = f"cazy_webscraper version: {__version__}"

--- a/cazy_webscraper/expand/genbank/genomes/get_genome_accs.py
+++ b/cazy_webscraper/expand/genbank/genomes/get_genome_accs.py
@@ -123,6 +123,19 @@ def main(argv: Optional[List[str]] = None, logger: Optional[logging.Logger] = No
         ec_filters,
     ) = parse_configuration.get_expansion_configuration(args)
 
+    with sql_orm.Session(bind=connection) as session:
+        sql_interface.log_scrape_in_db(
+            time_stamp,
+            config_dict,
+            kingdom_filters,
+            taxonomy_filter_dict,
+            ec_filters,
+            'NCBI Assembly',
+            'Genomic assemly accessions',
+            session,
+            args,
+        )
+
     logger.info(f"Retrieving Genbank records from the local db:\n{str(args.database)}")
 
     gbk_dict = get_gbks_of_interest(

--- a/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
+++ b/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
@@ -575,7 +575,7 @@ def get_lineage_protein_data(tax_ids, prot_id_dict, gbk_dict, cache_dir, args):
     lineage_dict, failed_ids = get_lineage_data(tax_ids, args)
     logger.warning(
         f"Queried NCBI with {len(tax_ids)} tax ids\n"
-        f"Retrieving lineages for {len(list(lineage_dict.keys()))} tax ids"
+        f"Retrieved lineages for {len(list(lineage_dict.keys()))} tax ids"
     )
 
     if len(list(lineage_dict.keys())) == 0:

--- a/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
+++ b/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
@@ -115,7 +115,7 @@ def main(argv: Optional[List[str]] = None, logger: Optional[logging.Logger] = No
             config_dict,
             kingdom_filters,
             taxonomy_filter_dict,
-            set(),  # ec_filters not applied when scraping CAZy
+            ec_filters,  # ec_filters not applied when scraping CAZy
             'NCBI Taxonomy',
             'NCBI taxonomc lineages',
             session,

--- a/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
+++ b/cazy_webscraper/expand/genbank/taxonomy/get_ncbi_taxs.py
@@ -661,7 +661,7 @@ def get_lineage_data(tax_ids, args):
     * set of tax ids for which data could not be retrieved from NCBI
     """
     all_tax_lineage_dict = {}  # {ncbi tax id: {rank: str}}
-    og_batches = get_chunks_list(tax_ids, args.batch_size)
+    og_batches = get_chunks_list(list(tax_ids), args.batch_size)
 
     tax_lineage_dict, failed_batches, unlisted_id_batches = get_taxid_lineages(
         og_batches,

--- a/cazy_webscraper/expand/gtdb/get_gtdb_tax.py
+++ b/cazy_webscraper/expand/gtdb/get_gtdb_tax.py
@@ -123,6 +123,19 @@ def main(argv: Optional[List[str]] = None, logger: Optional[logging.Logger] = No
         ec_filters,
     ) = get_expansion_configuration(args)
 
+    with sql_orm.Session(bind=connection) as session:
+        sql_interface.log_scrape_in_db(
+            time_stamp,
+            config_dict,
+            kingdom_filters,
+            taxonomy_filter_dict,
+            ec_filters,
+            'Genome Taxonomy DataBase (GTDB)',
+            'GTDB taxonomc lineages',
+            session,
+            args,
+        )
+
     # get the GenBank verion accessions and local db IDs of proteins matching the config criteria
     gbk_dict = get_gbks_of_interest(
         class_filters,

--- a/cazy_webscraper/ncbi/taxonomy/lineage.py
+++ b/cazy_webscraper/ncbi/taxonomy/lineage.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# (c) University of St Andrews 2022
+# (c) University of Strathclyde 2022
+# (c) James Hutton Institute 2022
+# Author:
+# Emma E. M. Hobbs
+#
+# Contact
+# eemh1@st-andrews.ac.uk
+#
+# Emma E. M. Hobbs,
+# Biomolecular Sciences Building,
+# University of St Andrews,
+# North Haugh Campus,
+# St Andrews,
+# KY16 9ST
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Parse taxonomy data from NCBI and CAZy to replace when multiple taxa are retrieved from CAZy"""
+
+
+import logging
+
+from saintBioutils.genbank import entrez_retry
+from tqdm import tqdm
+
+from Bio import Entrez
+
+
+def fetch_lineages(tax_ids, query_key, web_env, args):
+    """Fetch lineage data from NCBI Taxonomy database.
+
+    :param tax_ids: list of NCBI tax ids
+    :param query_key: str, query key from ncbi.entrez.epost
+    :param web_env: str, web environment from ncbi.entrez.epost
+    :param args: CLI args parser
+
+    Return dict of lineage data {ncbi_tax_id: {rank: str/lineage}}
+        or None if connection fails
+    """
+    lineage_dict = {}  # {ncbi_tax_id: {rank: str/lineage}}
+
+    try:
+        with entrez_retry(
+            10,
+            Entrez.efetch,
+            db="Taxonomy",
+            query_key=qk,
+            WebEnv=we,
+        ) as handle:
+            batched_tax_records = Entrez.read(handle, validate=False)
+
+    except (TypeError, AttributeError) as err:
+        logger.warning(f"Failed to fetch tax record from NCBI tax for id '{tax_id}'':\n{err}")
+        return
+
+    for record in batched_tax_records:
+        record_id = record['TaxId']
+        if record_id not in tax_ids:
+            continue
+
+        # set all lineage data to None
+        kingdom, phylum, tax_class, order, family, genus, species, strain = None, None, None, None, None, None, None, None
+
+        for i in record['LineageEx']:
+            rank = i['Rank']
+
+            if rank == 'superkingdom':
+                kingdom = i['ScientificName']
+
+            elif rank == 'phylum':
+                phylum = i['ScientificName']
+
+            elif rank == 'class':
+                tax_class = i['ScientificName']
+
+            elif rank == 'order':
+                order = i['ScientificName']
+
+            elif rank == 'family':
+                family = i['ScientificName']
+
+            elif rank == 'genus':
+                genus = i['ScientificName']
+
+            elif rank == 'species' or 'species group':
+                species = i['ScientificName']
+
+            elif rank == 'serotype' or 'strain':
+                strain = i['ScientificName']
+
+        scientific_name = record['ScientificName']
+
+        if genus is not None:
+            # drop genus from species name
+            if species is not None:
+                species = species.replace(genus, "").strip()
+
+            # extract strain from scientific name if not retrieved as rank
+            if species is not None and strain is None:
+                strain = scientific_name.replace(f"{genus} {species}", "").strip()
+
+            # extract species from the scientific name if not retrieved as rank
+            elif species is None:
+                species = scientific_name.replace(genus, "").strip()
+
+        lineage_dict[record_id] = {
+            'kingdom': kingdom,
+            'phylum': phylum,
+            'class': tax_class,
+            'order': order,
+            'family': family,
+            'genus': genus,
+            'species': species,
+            'strain': strain,
+        }
+
+    return lineage_dict

--- a/cazy_webscraper/ncbi/taxonomy/lineage.py
+++ b/cazy_webscraper/ncbi/taxonomy/lineage.py
@@ -42,12 +42,11 @@
 
 import logging
 
-from copy import copy
-
+from Bio import Entrez
 from saintBioutils.genbank import entrez_retry
 from tqdm import tqdm
 
-from Bio import Entrez
+from cazy_webscraper.ncbi import post_ids
 
 
 def fetch_lineages(tax_ids, query_key, web_env, args):

--- a/cazy_webscraper/ncbi/taxonomy/lineage.py
+++ b/cazy_webscraper/ncbi/taxonomy/lineage.py
@@ -68,7 +68,7 @@ def fetch_lineages(tax_ids, query_key, web_env, args):
             Entrez.efetch,
             db="Taxonomy",
             query_key=query_key,
-            WebEnv=we,
+            WebEnv=web_env,
         ) as handle:
             batched_tax_records = Entrez.read(handle, validate=False)
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ with Path("README.md").open("r") as long_description_handle:
 
 setuptools.setup(
     name="cazy_webscraper",
-    version="2.2.7",
+    version="2.2.8",
     # Metadata
     author="Emma E. M. Hobbs",
     author_email="eemh1@st-andrews.ac.uk",


### PR DESCRIPTION
Adding batch retrieval of lineage data from the NCBI Taxonomy database.  This reduces the execution time for `cw_get_ncbi_taxs` and reduces the burden on the NCBI.Entrez server.